### PR TITLE
fix for issue# 30: allow conf_mute_status in calls.update()

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,7 @@ const validateCallUpdate = (opts) => {
     call_status,
     listen_status,
     mute_status,
+    conf_mute_status,
     whisper,
     conf_hold_status,
     sip_request,
@@ -21,7 +22,7 @@ const validateCallUpdate = (opts) => {
   } = opts;
 
   assert.ok(call_hook || child_call_hook || call_status ||
-    listen_status || mute_status || whisper  || dub ||
+    listen_status || mute_status || conf_mute_status || whisper  || dub ||
     conf_hold_status || sip_request, `calls.update: invalid request ${JSON.stringify(opts)}`);
 
   if (call_status) assert.ok(['completed', 'no-answer'].includes(call_status),
@@ -30,8 +31,11 @@ const validateCallUpdate = (opts) => {
   if (mute_status) assert.ok(['mute', 'unmute'].includes(mute_status),
     `invalid mute_status: ${mute_status}, must be 'mute' or 'unmute'`);
 
+  if (conf_mute_status) assert.ok(['mute', 'unmute'].includes(conf_mute_status),
+    `invalid conf_mute_status: ${conf_mute_status}, must be 'mute' or 'unmute'`);
+
   if (conf_hold_status) assert.ok(['hold', 'unhold'].includes(conf_hold_status),
-    `invalid mute_status: ${mute_status}, must be 'mute' or 'unmute'`);
+    `invalid conf_hold_status: ${conf_hold_status}, must be 'hold' or 'unhold'`);
 
   if (media_path) assert.ok(['no-media', 'partial-media', 'full-media'].includes(media_path),
     `invalid media_path: ${media_path}, must be 'no-media', 'partial-media' or 'full-media'`);


### PR DESCRIPTION
Simple fix to allow `conf_mute_status` with `mute` | `unmute` values, same as `mute_status` @davehorton @sammachin 