### PR TITLE
Add TypeScript type declarations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 test/*
+types/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,9 @@
         "eslint": "^8.20.0",
         "eslint-plugin-promise": "^6.0.0",
         "nyc": "^15.1.0",
-        "tape": "^5.7.5"
+        "tape": "^5.7.5",
+        "typescript": "^5.9.3",
+        "yaml": "^2.8.2"
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.6",
@@ -4476,6 +4478,20 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -4703,6 +4719,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "0.4.11",
   "description": "Node.js client for building jambonz applications (jambonz.org)",
   "main": "lib/index.js",
+  "types": "types/jambonz-node-client.d.ts",
   "scripts": {
     "test": "NODE_ENV=test node test/ ",
     "coverage": "./node_modules/.bin/nyc --reporter html --report-dir ./coverage npm run test",
-    "jslint": "eslint lib"
+    "jslint": "eslint lib",
+    "generate-types": "node scripts/generate-types.js"
   },
   "author": "Dave Horton",
   "repository": {
@@ -26,7 +28,9 @@
     "eslint": "^8.20.0",
     "eslint-plugin-promise": "^6.0.0",
     "nyc": "^15.1.0",
-    "tape": "^5.7.5"
+    "tape": "^5.7.5",
+    "typescript": "^5.9.3",
+    "yaml": "^2.8.2"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.6",

--- a/schema/calls.yaml
+++ b/schema/calls.yaml
@@ -1,0 +1,673 @@
+openapi: 3.0.0
+info:
+  title: Jambonz API
+  description: Jambonz REST API specification
+  contact:
+    email: daveh@drachtio.org
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+  version: 1.0.0
+servers:
+  - url: https://api.jambonz.cloud/v1
+security:
+  - bearerAuth: []
+tags:
+  - name: Calls
+    description: Control Calls
+  - name: Conferences
+    description: Confernce Participants
+
+paths:
+  /Accounts/{AccountSid}/Calls:
+    post:
+      tags:
+        - Calls
+      summary: create a call
+      operationId: createCall
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+                - from
+                - to
+              type: object
+              properties:
+                application_sid:
+                  type: string
+                  format: uuid
+                  description: The application to use to control this call.  Either application_sid or call_hook is required.
+                answerOnBridge:
+                  type: boolean
+                  description: If set to true, the inbound call will ring until the number that was dialed answers the call, and at that point a 200 OK will be sent on the inbound leg.  If false, the inbound call will be answered immediately as the outbound call is placed.
+                  example: false
+                call_hook:
+                  $ref: "#/components/schemas/Webhook"
+                  example:
+                    url: https://example.com/callhook
+                    method: POST
+                call_status_hook:
+                  $ref: "#/components/schemas/Webhook"
+                  example:
+                    url: https://example.com/status
+                    method: POST
+                from:
+                  type: string
+                  description: The calling party number
+                  example: "16175551212"
+                fromHost:
+                  type: string
+                  description: The hostname to put in the SIP From header of the INVITE
+                  example: sip.example.com
+                timeout:
+                  type: integer
+                  description: The number of seconds to wait for call to be answered.  Defaults to 60.
+                  example: 30
+                timeLimit:
+                  type: integer
+                  description: The max length of call in seconds
+                  example: 60
+                tag:
+                  type: object
+                  description: Initial set of customer-supplied metadata to associate with the call (see jambonz 'tag' verb)
+                  example:
+                    callCount: 10
+                to:
+                  $ref: "#/components/schemas/Target"
+                  description: Destination for call
+                headers:
+                  type: object
+                  description: The customer SIP headers to associate with the call
+                  example:
+                    X-Custom-Header: Hello
+                sipRequestWithinDialogHook:
+                  type: string
+                  description: The sip indialog hook to receive session messages
+                  example: /customHook
+                speech_synthesis_vendor:
+                  type: string
+                  description: The vendor for Text to Speech (required if application_sid is not used)
+                  example: google
+                speech_synthesis_language:
+                  type: string
+                  description: The language for Text to Speech (required if application_sid is not used)
+                  example: en-US
+                speech_synthesis_voice:
+                  type: string
+                  description: The voice for Text to Speech (required if application_sid is not used)
+                  example: Wavenet-A
+                speech_recognizer_vendor:
+                  type: string
+                  description: The vendor for Speech to Text (required if application_sid is not used)
+                  example: google
+                speech_recognizer_language:
+                  type: string
+                  description: The language for Speech to Text (required if application_sid is not used)
+                  example: en-US
+                amd:
+                  $ref: "#/components/schemas/amd"
+      responses:
+        "201":
+          description: call successfully created
+          content:
+            application/json:
+              schema:
+                required:
+                  - sid
+                properties:
+                  sid:
+                    type: string
+                    format: uuid
+                    example: 2531329f-fb09-4ef7-887e-84e648214436
+        "400":
+          description: bad request
+    get:
+      tags:
+        - Calls
+      summary: list calls
+      operationId: listCalls
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: direction
+          required: false
+          schema:
+            type: string
+            enum:
+              - inbound
+              - outbound
+          description: call direction to retrieve
+        - in: query
+          name: from
+          required: false
+          schema:
+            type: string
+          description: calling number to retrieve
+        - in: query
+          name: to
+          required: false
+          schema:
+            type: string
+          description: called number to retrieve
+        - in: query
+          name: callStatus
+          required: false
+          schema:
+            type: string
+            enum:
+              - trying
+              - ringing
+              - early-media
+              - in-progress
+              - completed
+              - failed
+              - busy
+              - no-answer
+              - queued
+          description: call status to retrieve
+      responses:
+        "200":
+          description: list of calls for a specified account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Call"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}/Calls/{CallSid}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: CallSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Calls
+      summary: delete a call
+      operationId: deleteCall
+      responses:
+        "204":
+          description: call successfully deleted
+        "404":
+          description: call not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Calls
+      summary: retrieve a call
+      operationId: getCall
+      responses:
+        "200":
+          description: call found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Call"
+        "404":
+          description: call not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Calls
+      summary: update a call
+      operationId: updateCall
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                call_hook:
+                  $ref: "#/components/schemas/Webhook"
+                child_call_hook:
+                  $ref: "#/components/schemas/Webhook"
+                call_status:
+                  type: string
+                  enum:
+                    - completed
+                    - no-answer
+                conf_mute_status:
+                  type: string
+                  enum:
+                    - mute
+                    - unmute
+                conf_hold_status:
+                  type: string
+                  enum:
+                    - hold
+                    - unhold
+                listen_status:
+                  type: string
+                  enum:
+                    - pause
+                    - silence
+                    - resume
+                mute_status:
+                  type: string
+                  enum:
+                    - mute
+                    - unmute
+                transcribe_status:
+                  type: string
+                  enum:
+                    - pause
+                    - resume
+                whisper:
+                  oneOf:
+                    - type: object
+                      properties:
+                        verb:
+                          enum:
+                            - say
+                            - play
+                          description: See [Say](/verbs/verbs/say) or [Play](/verbs/verbs/play) for details of the properties
+                    - type: array
+                      items:
+                        type: object
+                        properties:
+                          verb:
+                            enum:
+                              - say
+                              - play
+                            description: See [Say](/verbs/verbs/say) or [Play](/verbs/verbs/play) for details of the properties
+                sip_request:
+                  type: object
+                  properties:
+                    method:
+                      type: string
+                    content_type:
+                      type: string
+                    content:
+                      type: string
+                    headers:
+                      type: object
+                record:
+                  type: object
+                  properties:
+                    action:
+                      type: string
+                      enum:
+                        - startCallRecording
+                        - stopCallRecording
+                        - pauseCallRecording
+                        - resumeCallRecording
+                    recordingID:
+                      type: string
+                    siprecServerURL:
+                      type: string
+                conferenceParticipantAction:
+                  type: object
+                  properties:
+                    action:
+                      type: string
+                      enum:
+                        - tag
+                        - untag
+                        - coach
+                        - uncoach
+                        - mute
+                        - unmute
+                        - hold
+                        - unhold
+                    tag:
+                      type: string
+                dtmf:
+                  type: object
+                  properties:
+                    digit:
+                      type: string
+                      enum:
+                        - "1"
+                        - "2"
+                        - "3"
+                        - "4"
+                        - "5"
+                        - "6"
+                        - "7"
+                        - "8"
+                        - "9"
+                        - "0"
+                        - "*"
+                        - "#"
+                      description: "Single digit to send"
+                    duration:
+                      type: integer
+                      default: 250
+                      description: "Duration of the tone in ms"
+                  required:
+                    - digit
+      responses:
+        "200":
+          description: Accepted
+        "202":
+          description: Accepted
+        "400":
+          description: bad request
+        "404":
+          description: call not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}/Queues:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: search
+        required: false
+        schema:
+          type: string
+          description: queue name of data to retrieve
+    get:
+      tags:
+        - Queues
+      summary: retrieve active queues for an account
+      operationId: listQueues
+      responses:
+        "200":
+          description: retrieve active queues records for a specified account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    length:
+                      type: string
+  /Accounts/{AccountSid}/Conferences:
+    get:
+      tags:
+        - Conferences
+      summary: list conferences
+      operationId: listConferences
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: list of conferences for a specified account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}/CallCount:
+    get:
+      tags:
+        - Calls
+      summary: get call count
+      operationId: getCallCount
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: count of active calls for an account
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inbound:
+                    type: number
+                    description: Number of inbound calls to the platform
+                    example: 2
+                  outbound:
+                    type: number
+                    description: Number of outbound calls to the platform
+                    example: 0
+        "400":
+          description: error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: token
+  schemas:
+    GeneralError:
+      type: object
+      required:
+        - msg
+      properties:
+        msg:
+          type: string
+      example:
+        msg: specific error detail will be provided here
+    Webhook:
+      type: object
+      properties:
+        webhook_sid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          format: url
+        method:
+          type: string
+          enum:
+            - get
+            - post
+        username:
+          type: string
+        password:
+          type: string
+      required:
+        - url
+      example:
+        url: https://acme.com
+        method: POST
+    Call:
+      type: object
+      properties:
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+        call_id:
+          type: string
+        call_sid:
+          type: string
+          format: uuid
+        call_status:
+          type: string
+          enum:
+            - trying
+            - ringing
+            - alerting
+            - in-progress
+            - completed
+            - busy
+            - no-answer
+            - failed
+            - queued
+        caller_name:
+          type: string
+        direction:
+          type: string
+          enum:
+            - inbound
+            - outbound
+        duration:
+          type: integer
+        from:
+          type: string
+        originating_sip_trunk_name:
+          type: string
+        parent_call_sid:
+          type: string
+          format: uuid
+        service_url:
+          type: string
+        sip_status:
+          type: integer
+        to:
+          type: string
+      required:
+        - account_sid
+        - call_id
+        - call_sid
+        - call_status
+        - direction
+        - from
+        - service_url
+        - sip_status
+        - to
+    Target:
+      properties:
+        type:
+          type: string
+          enum:
+            - phone
+            - sip
+            - user
+            - teams
+        number:
+          type: string
+          description: A phone number to call (when type is phone)
+        sipUri:
+          type: string
+          description: A SIP URI to call (when type is sip)
+        tenant:
+          type: string
+          description: Microsoft Teams customer tenant domain name (when type is teams)
+        trunk:
+          type: string
+          description: The name of the Carrier that should be used to deliver this call (when type is phone)
+        vmail:
+          type: boolean
+          description: Dial directly into user's voicemail to leave a message (MS Teams only)
+        overrideTo:
+          type: string
+          description: A SIP URI that, if provided, will be used as the To header in the outbound INVITE (not needed in most cases)
+        name:
+          type: string
+          description: The name of a registered jambonz user to call (when type is user)
+        auth:
+          type: object
+          properties:
+            username:
+              type: string
+              description: The username to use for SIP authentication, if challenged
+            password:
+              type: string
+              description: The password to use for SIP authentication, if challenged
+        proxy:
+          type: string
+          description: SIP Proxy to use for the outgoing INVITE
+          example: sip:192.0.0.1:5080
+      required:
+        - type
+      example:
+        type: phone
+        number: "+16172375080"
+    amd:
+      type: object
+      properties:
+        actionHook:
+          type: string
+          description: Webhook to send AMD events.
+        thresholdWordCount:
+          type: number
+          description: Number of spoken words in a greeting that result in an amd_machine_detected result.
+        digitCount:
+          type: number
+          description: Number of digits in a greeting to trigger a amd_machine_detected result. 0 is off
+        timers:
+          type: object
+          properties:
+            decisionTimeoutMs:
+              type: number
+              default: 15000
+              description: Time in milliseconds to wait before returning amd_decision_timeout.
+            greetingCompletionTimeoutMs:
+              type: number
+              default: 2000
+              description: Silence in milliseconds to wait for during greeting before returning amd_machine_stopped_speaking.
+            noSpeechTimeoutMs:
+              type: number
+              default: 5000
+              description: Time in milliseconds to wait for speech before returning amd_no_speech_detected.
+            toneTimeoutMs:
+              type: number
+              default: 20000
+              description: Time in milliseconds to wait to hear a tone.

--- a/schema/platform.yaml
+++ b/schema/platform.yaml
@@ -1,0 +1,5199 @@
+openapi: 3.0.0
+info:
+  title: Jambonz API
+  description: Jambonz REST API specification
+  contact:
+    email: daveh@drachtio.org
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+  version: 1.0.0
+servers:
+  - url: https://api.jambonz.cloud/v1
+security:
+  - bearerAuth: []
+tags:
+  - name: Users
+    description: User Management
+  - name: Settings
+    description: General Settings
+  - name: Accounts
+    description: Account Settings
+  - name: Clients
+    description: SIP Clients
+  - name: Applications
+    description: Applications
+  - name: Recent Calls
+    description: Details of calls
+  - name: Alerts
+    description: Alerts of Errors and failures
+  - name: Carriers
+    description: SIP Carriers & Trunks
+  - name: Speech
+    description: Text to Speech & Speech to Text Providers
+  - name: Phone Numbers
+    description: Routing of Phone numbers to Applications
+  - name: Call Routing
+    description: Least cost Call Routing
+paths:
+  /Sbcs:
+    get:
+      tags:
+        - Carriers
+      summary: retrieve public IP addresses of the jambonz SBCs
+      operationId: listSbcs
+      parameters:
+        - in: query
+          name: service_provider_sid
+          required: false
+          schema:
+            type: string
+            description: return only the SBCs operated for the sole use of this service provider
+      responses:
+        "200":
+          description: list of SBC addresses
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    ipv4:
+                      type: string
+                      description: ip address of one of our Sbcs
+                  required:
+                    - ipv4
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /ApiKeys/{ApiKeySid}:
+    parameters:
+      - name: ApiKeySid
+        in: path
+        required: true
+        schema:
+          type: string
+  /Users:
+    post:
+      tags:
+        - Users
+      summary: create a new user
+      operationId: createUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - is_active
+                - force_change
+                - is_view_only
+                - initial_password
+                - email
+              properties:
+                name:
+                  type: string
+                  description: username
+                  example: my_user
+                email:
+                  type: string
+                  description: user email address
+                  example: user@example.com
+                is_active:
+                  type: boolean
+                  description: user account is active
+                force_change:
+                  type: boolean
+                  description: require the user to change password on next login
+                initial_password:
+                  type: string
+                  description: users password
+                  example: MySecurePassword
+                account_sid:
+                  type: string
+                  format: uuid
+                  description: account sid the account the user will have access to, if not set will create a Service Provider account
+                service_provider_sid:
+                  type: string
+                  format: uuid
+                  description: The service provider sid, the account is under, if not set account will be admin level
+                is_view_only:
+                  type: boolean
+                  description: if set to true the user will not be able to make changes
+      responses:
+        "200":
+          description: user created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_sid:
+                    type: string
+                    format: uuid
+                    description: The sid of the newly created user
+                    example: "58b8ec3a-6fcc-4fd7-8f45-cff054c2ebe9"
+        "403":
+          description: user creation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Users/{UserSid}:
+    parameters:
+      - name: UserSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    get:
+      tags:
+        - Users
+      summary: retrieve user information
+      operationId: getUser
+      responses:
+        "200":
+          description: user information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_sid:
+                    type: string
+                    format: uuid
+                    example: "58b8ec3a-6fcc-4fd7-8f45-cff054c2ebe9"
+                  name:
+                    type: string
+                    description: username
+                    example: my_user
+                  email:
+                    type: string
+                    description: user email address
+                    example: user@example.com
+                  is_active:
+                    type: number
+                    description: user account is active
+                    enum:
+                      - 0
+                      - 1
+                  force_change:
+                    type: number
+                    description: require the user to change password on next login
+                    enum:
+                      - 0
+                      - 1
+                  account_sid:
+                    type: string
+                    format: uuid
+                    description: account sid the account the user will have access to, if not set will create a Service Provider account
+                  service_provider_sid:
+                    type: string
+                    format: uuid
+                    description: The service provider sid, the account is under, if not set account will be admin level
+                  is_view_only:
+                    type: boolean
+                    description: If set to true the user will not be able to make changes
+                  provider:
+                    type: string
+                    enum:
+                      - local
+                  provider_user_id:
+                    type: string
+                  scope:
+                    type: string
+                    enum:
+                      - read-write
+                  phone_activation_code:
+                    type: string
+                  email_activation_code:
+                    type: string
+                  email_validated:
+                    type: number
+                    enum:
+                      - 0
+                      - 1
+                  phone_validated:
+                    type: number
+                    enum:
+                      - 0
+                      - 1
+                  email_content_opt_out:
+                    type: number
+                    enum:
+                      - 0
+                      - 1
+                  pending_email:
+                    type: string
+                  phone:
+                    type: string
+        "403":
+          description: user information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Users
+      summary: update user information
+      operationId: updateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                email_activation_code:
+                  type: string
+                old_password:
+                  type: string
+                  description: existing password, which is to be replaced
+                new_password:
+                  type: string
+                  description: new password
+                is_active:
+                  type: boolean
+                force_change:
+                  type: boolean
+                is_view_only:
+                  type: boolean
+                  description: if set to true the user will not be able to make changes
+      responses:
+        "204":
+          description: user updated
+        "403":
+          description: user update failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    delete:
+      tags:
+        - Users
+      summary: delete a user
+      operationId: deleteUser
+      responses:
+        "204":
+          description: user deleted
+        "403":
+          description: unauthorized
+        "404":
+          description: user not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Availability:
+    get:
+      tags:
+        - Accounts
+      summary: check if a limited-availability entity such as a subdomain, email or phone number is already in use
+      operationId: checkAvailability
+      parameters:
+        - in: query
+          name: type
+          required: true
+          schema:
+            type: string
+            enum:
+              - email
+              - phone
+              - subdomain
+            example: subdomain
+        - in: query
+          name: value
+          required: true
+          schema:
+            type: string
+            example: mycorp.sip.jambonz.cloud
+      responses:
+        "200":
+          description: indicates whether value is already in use
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                    description: true if value requested is available
+                required:
+                  - available
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Webhooks/{WebhookSid}:
+    parameters:
+      - name: WebhookSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    get:
+      tags:
+        - Applications
+      summary: retrieve webhook
+      operationId: getWebhook
+      responses:
+        "200":
+          description: webhook found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Webhook"
+        "404":
+          description: webhook not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /VoipCarriers/{VoipCarrierSid}:
+    parameters:
+      - name: VoipCarrierSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Carriers
+      summary: delete a voip carrier
+      operationId: deleteVoipCarrier
+      responses:
+        "204":
+          description: voip carrier successfully deleted
+        "404":
+          description: voip carrier not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+                example:
+                  msg: a service provider with active accounts can not be deleted
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Carriers
+      summary: retrieve voip carrier
+      operationId: getVoipCarrier
+      responses:
+        "200":
+          description: voip carrier found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VoipCarrier"
+        "404":
+          description: voip carrier not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Carriers
+      summary: update voip carrier
+      operationId: updateVoipCarrier
+      parameters:
+        - name: VoipCarrierSid
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VoipCarrier"
+      responses:
+        "204":
+          description: voip carrier updated
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "404":
+          description: voip carrier not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /SipGateways:
+    post:
+      tags:
+        - Carriers
+      summary: create sip gateway
+      operationId: createSipGateway
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                voip_carrier_sid:
+                  type: string
+                  description: voip carrier that provides this gateway
+                  format: uuid
+                ipv4:
+                  type: string
+                netmask:
+                  type: integer
+                port:
+                  type: integer
+                is_active:
+                  type: boolean
+                inbound:
+                  type: boolean
+                outbound:
+                  type: boolean
+              required:
+                - voip_carrier_sid
+                - ipv4
+      responses:
+        "201":
+          description: sip gateway successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Carriers
+      summary: list sip gateways
+      operationId: listSipGateways
+      parameters:
+        - in: query
+          name: voip_carrier_sid
+          required: true
+          schema:
+            type: string
+            description: return only the SipGateways operated for this VoipCarrier
+      responses:
+        "200":
+          description: list of sip gateways
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SipGateway"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /SipGateways/{SipGatewaySid}:
+    parameters:
+      - name: SipGatewaySid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Carriers
+      summary: delete a sip gateway
+      operationId: deleteSipGateway
+      responses:
+        "204":
+          description: sip gateway successfully deleted
+        "404":
+          description: sip gateway not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Carriers
+      summary: retrieve sip gateway
+      operationId: getSipGateway
+      responses:
+        "200":
+          description: sip gateway found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SipGateway"
+        "404":
+          description: sip gateway not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Carriers
+      summary: update sip gateway
+      operationId: updateSipGateway
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SipGateway"
+      responses:
+        "204":
+          description: sip gateway updated
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "404":
+          description: sip gateway not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /SmppGateways/{SmppGatewaySid}:
+    parameters:
+      - name: SmppGatewaySid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+  /PhoneNumbers:
+    post:
+      tags:
+        - Phone Numbers
+      summary: provision a phone number into inventory from a Voip Carrier
+      operationId: provisionPhoneNumber
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                account_sid:
+                  type: string
+                  format: uuid
+                application_sid:
+                  type: string
+                  format: uuid
+                number:
+                  type: string
+                  description: telephone number
+                voip_carrier_sid:
+                  type: string
+                  format: uuid
+              required:
+                - number
+                - voip_carrier_sid
+      responses:
+        "201":
+          description: phone number successfully provisioned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+              example:
+                msg: invalid telephone number format
+        "404":
+          description: voip carrier not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+                example:
+                  msg: the phone number provided already exists in inventory
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Phone Numbers
+      summary: list phone numbers
+      operationId: listProvisionedPhoneNumbers
+      responses:
+        "200":
+          description: list of phone numbers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PhoneNumber"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /PhoneNumbers/{PhoneNumberSid}:
+    parameters:
+      - name: PhoneNumberSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Phone Numbers
+      summary: delete a phone number
+      operationId: deletePhoneNumber
+      responses:
+        "204":
+          description: phone number successfully deleted
+        "404":
+          description: phone number not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+                example:
+                  msg: phone number that is assigned to an account may not be deleted
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Phone Numbers
+      summary: retrieve phone number
+      operationId: getPhoneNumber
+      responses:
+        "200":
+          description: phone number found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhoneNumber"
+        "404":
+          description: phone number not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Phone Numbers
+      summary: update phone number
+      operationId: updatePhoneNumber
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PhoneNumber"
+      responses:
+        "204":
+          description: phone number updated
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "404":
+          description: phone number not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts:
+    post:
+      tags:
+        - Accounts
+      summary: create an account
+      operationId: createAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: account name
+                  example: foobar
+                sip_realm:
+                  type: string
+                  description: sip realm for registration
+                  example: sip.mycompany.com
+                registration_hook:
+                  $ref: "#/components/schemas/Webhook"
+                  description: authentication webhook for registration
+                queue_event_hook:
+                  $ref: "#/components/schemas/Webhook"
+                  description: webhook called when members join or leave a queue
+                service_provider_sid:
+                  type: string
+                  format: uuid
+                  example: 85f9c036-ba61-4f28-b2f5-617c23fa68ff
+              required:
+                - name
+                - service_provider_sid
+      responses:
+        "201":
+          description: account successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Accounts
+      summary: list accounts
+      operationId: listAccounts
+      responses:
+        "200":
+          description: list of accounts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Account"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    delete:
+      tags:
+        - Accounts
+      summary: delete an account
+      operationId: deleteAccount
+      responses:
+        "204":
+          description: account successfully deleted
+        "404":
+          description: account not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Accounts
+      summary: retrieve account
+      operationId: getAccount
+      responses:
+        "200":
+          description: account found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Account"
+        "404":
+          description: account not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Accounts
+      summary: update account
+      operationId: updateAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Account"
+      responses:
+        "204":
+          description: account updated
+        "404":
+          description: account not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}/WebhookSecret:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: regenerate
+        in: query
+        required: false
+        schema:
+          type: boolean
+    get:
+      tags:
+        - Accounts
+      summary: get webhook signing secret, regenerating if requested
+      operationId: getWebhookSecret
+      responses:
+        "200":
+          description: secret
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  webhook_secret:
+                    type: string
+        "404":
+          description: account not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}/SipRealms/{SipRealm}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: SipRealm
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      tags:
+        - Accounts
+      summary: add or change the sip realm
+      operationId: createSipRealm
+      responses:
+        "204":
+          description: sip_realm updated and DNS entries successfully created
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}/SpeechCredentials:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Speech
+      summary: add a speech credential
+      operationId: createSpeechCredential
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpeechCredential"
+      responses:
+        "201":
+          description: speech credential successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Speech
+      summary: retrieve all speech credentials for an account
+      operationId: listSpeechCredentials
+      responses:
+        "200":
+          description: retrieve speech credentials for a specified account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SpeechCredential"
+        "404":
+          description: account not found
+  /Accounts/{AccountSid}/SpeechCredentials/{SpeechCredentialSid}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: SpeechCredentialSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Speech
+      summary: get a specific speech credential
+      operationId: getSpeechCredentialByAccount
+      responses:
+        "200":
+          description: retrieve speech credentials for a specified account
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpeechCredential"
+        "404":
+          description: credential not found
+    put:
+      tags:
+        - Speech
+      summary: update a speech credential
+      operationId: updateSpeechCredentialByAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpeechCredentialUpdate"
+      responses:
+        "204":
+          description: credential successfully deleted
+        "404":
+          description: credential not found
+        "422":
+          description: credential not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    delete:
+      tags:
+        - Speech
+      summary: delete a speech credential
+      operationId: deleteSpeechCredentialByAccount
+      responses:
+        "204":
+          description: credential successfully deleted
+        "404":
+          description: credential not found
+  /Accounts/{AccountSid}/SpeechCredentials/speech/supportedLanguagesAndVoices:
+    get:
+      tags:
+        - Speech
+      summary: get supported languages, voices and models
+      operationId: supportedLanguagesAndVoicesByAccount
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: vendor
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: label
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: get supported languages, voices and models
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpeechLanguagesVoices"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}/SpeechCredentials/{SpeechCredentialSid}/test:
+    get:
+      tags:
+        - Speech
+      summary: test a speech credential
+      operationId: testSpeechCredentialByAccount
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: SpeechCredentialSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: credential test results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tts:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum:
+                          - success
+                          - fail
+                          - not tested
+                      reason:
+                        type: string
+                  stt:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum:
+                          - success
+                          - fail
+                      reason:
+                        type: string
+        "404":
+          description: credential not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}/RecentCalls:
+    get:
+      tags:
+        - Recent Calls
+      summary: retrieve recent calls for an account
+      operationId: listRecentCalls
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: integer
+            description: page number of data to retrieve
+        - in: query
+          name: count
+          required: true
+          schema:
+            type: integer
+            description: number of rows to retrieve in each page set
+            minimum: 1
+            maximum: 500
+        - in: query
+          name: days
+          required: false
+          schema:
+            type: integer
+            description: number of days back to retrieve,
+            minimum: 1
+            maximum: 30
+        - in: query
+          name: start
+          required: false
+          schema:
+            type: string
+            format: date-time
+            description: start date to retrieve
+        - in: query
+          name: end
+          required: false
+          schema:
+            type: string
+            format: date-time
+            description: end date to retrieve
+        - in: query
+          name: answered
+          required: false
+          schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+            description: retrieve only answered calls
+        - in: query
+          name: direction
+          required: false
+          schema:
+            type: string
+            enum:
+              - inbound
+              - outbound
+        - in: query
+          name: filter
+          required: false
+          schema:
+            type: string
+          description: Filter value can be caller ID, callee ID or call Sid
+      responses:
+        "200":
+          description: retrieve recent call records for a specified account
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    description: total number of records in that database that match the filter criteria
+                  batch:
+                    type: integer
+                    description: total number of records returned in this page set
+                  page:
+                    type: integer
+                    description: page number that was requested, and is being returned
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        account_sid:
+                          type: string
+                          format: uuid
+                        call_sid:
+                          type: string
+                          format: uuid
+                        from:
+                          type: string
+                        to:
+                          type: string
+                        answered:
+                          type: boolean
+                        sip_call_id:
+                          type: string
+                        sip_status:
+                          type: integer
+                        duration:
+                          type: integer
+                        attempted_at:
+                          type: integer
+                        answered_at:
+                          type: integer
+                        terminated_at:
+                          type: integer
+                        termination_reason:
+                          type: string
+                        host:
+                          type: string
+                        remote_host:
+                          type: string
+                        direction:
+                          type: string
+                          enum:
+                            - inbound
+                            - outbound
+                        trunk:
+                          type: string
+                      required:
+                        - account_sid
+                        - call_sid
+                        - attempted_at
+                        - terminated_at
+                        - answered
+                        - direction
+                        - from
+                        - to
+                        - sip_status
+                        - duration
+        "404":
+          description: account not found
+  /Accounts/{AccountSid}/RecentCalls/trace/{CallId}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: CallId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Recent Calls
+      summary: retrieve jaeger trace detail for a call
+      operationId: getRecentCallTrace
+      responses:
+        "200":
+          description: retrieve trace data
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: account or call not found
+  /Accounts/{AccountSid}/RecentCalls/{CallSid}/record/{YYYY}/{MM}/{DD}/{FORMAT}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: CallSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: YYYY
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: MM
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: DD
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: FORMAT
+        in: path
+        required: true
+        schema:
+          type: string
+          enum:
+            - wav
+            - mp3
+    get:
+      tags:
+        - Recent Calls
+      summary: retrieve recording for a call
+      operationId: getRecentCallRecording
+      responses:
+        "200":
+          description: call audio file
+          content:
+            application/octet-stream:
+              schema:
+                type: object
+        "404":
+          description: recording or call not found
+  /Accounts/{AccountSid}/PredefinedCarriers/{PredefinedCarrierSid}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: PredefinedCarrierSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+  /Accounts/{AccountSid}/Limits:
+    post:
+      tags:
+        - Accounts
+      summary: create a limit for an account
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: addLimitForAccount
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Limits"
+      responses:
+        "201":
+          description: limit successfully created or updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "404":
+          description: account not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Accounts
+      summary: retrieve call capacity and other limits from the account
+      operationId: getAccountLimits
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: account limits
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Limits"
+        "404":
+          description: account not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}/RecentCalls/{CallId}/pcap:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: CallId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Recent Calls
+      summary: retrieve pcap for a call
+      operationId: getRecentCallTraceByAccount
+      responses:
+        "200":
+          description: retrieve sip trace data
+          content:
+            application/octet-stream:
+              schema:
+                type: object
+        "404":
+          description: account or call not found
+  /Accounts/{AccountSid}/Alerts:
+    get:
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: true
+          schema:
+            type: integer
+            description: page number of data to retrieve
+        - name: count
+          in: query
+          required: true
+          schema:
+            type: integer
+            description: number of rows to retrieve in each page set
+            minimum: 1
+            maximum: 500
+        - name: days
+          in: query
+          required: false
+          schema:
+            type: integer
+            description: number of days back to retrieve,
+            minimum: 1
+            maximum: 30
+        - name: start
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+            description: start date to retrieve
+        - name: end
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+            description: end date to retrieve
+        - name: alert_type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - webhook-failure
+              - webhook-connection-failure
+              - webhook-auth-failure
+              - no-tts
+              - no-stt
+              - tts-failure
+              - stt-failure
+              - no-carrier
+              - call-limit
+              - device-limit
+              - api-limit
+      tags:
+        - Alerts
+      summary: retrieve alerts for an account
+      operationId: listAlertsByAccount
+      responses:
+        "200":
+          description: retrieve alerts for a specified account
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    description: total number of records in that database that match the filter criteria
+                  batch:
+                    type: integer
+                    description: total number of records returned in this page set
+                  page:
+                    type: integer
+                    description: page number that was requested, and is being returned
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        time:
+                          type: string
+                          format: date-time
+                        account_sid:
+                          type: string
+                          format: uuid
+                        alert_type:
+                          type: string
+                        message:
+                          type: string
+                        detail:
+                          type: string
+                      required:
+                        - time
+                        - account_sid
+                        - alert_type
+                        - message
+        "404":
+          description: account not found
+  /Applications:
+    post:
+      tags:
+        - Applications
+      summary: create application
+      operationId: createApplication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: application name
+                account_sid:
+                  type: string
+                  format: uuid
+                call_hook:
+                  $ref: "#/components/schemas/Webhook"
+                  description: application webhook to handle inbound voice calls
+                call_status_hook:
+                  $ref: "#/components/schemas/Webhook"
+                  description: webhook to report call status events
+                messaging_hook:
+                  $ref: "#/components/schemas/Webhook"
+                  description: application webhook to handle inbound SMS/MMS messages
+                app_json:
+                  type: string
+                  description: Voice Application Json, call_hook will not be invoked if app_json is provided
+                speech_synthesis_vendor:
+                  type: string
+                speech_synthesis_voice:
+                  type: string
+                speech_recognizer_vendor:
+                  type: string
+                speech_recognizer_language:
+                  type: string
+                env_vars:
+                  type: object
+                  description: Object containing the Application Environment Variables as key/value to be sent with the call_hook payload
+              required:
+                - name
+                - account_sid
+                - call_hook
+                - call_status_hook
+      responses:
+        "201":
+          description: application successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Applications
+      summary: list applications
+      operationId: listApplications
+      responses:
+        "200":
+          description: list of applications
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Application"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Applications/{ApplicationSid}:
+    parameters:
+      - name: ApplicationSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Applications
+      summary: delete an application
+      operationId: deleteApplication
+      responses:
+        "204":
+          description: application successfully deleted
+        "404":
+          description: application not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Applications
+      summary: retrieve an application
+      responses:
+        "200":
+          description: application found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Application"
+        "404":
+          description: application not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Applications
+      summary: update application
+      operationId: updateApplication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Application"
+      responses:
+        "204":
+          description: application updated
+        "404":
+          description: application not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Accounts/{AccountSid}/RegisteredSipUsers:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Clients
+      summary: retrieve online sip users for an account
+      operationId: listRegisteredSipUsers
+      responses:
+        "200":
+          description: retrieve online sip users for an account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+    post:
+      tags:
+        - Clients
+      summary: retrieve online sip users for an account by list of sip username
+      operationId: listRegisteredSipUsersByUsername
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        "200":
+          description: retrieve online sip users for an account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RegisteredClient"
+  /Accounts/{AccountSid}/RegisteredSipUsers/{Client}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: Client
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    get:
+      tags:
+        - Clients
+      summary: retrieve registered client registration
+      operationId: getRegisteredClient
+      responses:
+        "200":
+          description: registered client found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegisteredClient"
+  /Accounts/{AccountSid}/TtsCache/Synthesize:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Speech
+      summary: get TTS from provider
+      operationId: Synthesize
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                speech_credential_sid:
+                  type: string
+                  description: Speech credential Sid
+                  example: 553b4b6b-8918-4394-a46d-1e3c5a3c717b
+                text:
+                  type: string
+                  description: the text to convert to audio
+                  example: Hello How are you
+                language:
+                  type: string
+                  description: language is used in text
+                  example: en-US
+                voice:
+                  type: string
+                  description: voice ID
+                  example: en-US-Standard-C
+                encodingMp3:
+                  type: boolean
+                  description: convert audio to mp3.
+                  example: true
+              required:
+                - speech_credential_sid
+                - text
+                - language
+                - voice
+      responses:
+        "200":
+          description: Audio is created
+          content:
+            audio/mpeg:
+              schema:
+                type: string
+                format: binary
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /ApiKeys:
+    get:
+      tags:
+        - Accounts
+      summary: get all api keys for an account
+      operationId: getAccountApiKeys
+      responses:
+        "200":
+          description: list of api keys
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ApiKey"
+        "404":
+          description: account not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    post:
+      tags:
+        - Accounts
+      summary: create an API key for an account
+      operationId: createApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - account_sid
+              properties:
+                account_sid:
+                  type: string
+                  format: uuid
+                  example: "9d26a637-1679-471f-8da8-7150266e1254"
+      responses:
+        "200":
+          description: new API key
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sid:
+                    type: string
+                    format: uuid
+                  token:
+                    type: string
+                    format: uuid
+        "404":
+          description: account not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Clients:
+    get:
+      summary: List Clients
+      description: Returns a list of clients
+      operationId: getClients
+      tags:
+        - Clients
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: retrieve online sip users for an account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    account_sid:
+                      type: string
+                      format: uuid
+                      example: "9d26a637-1679-471f-8da8-7150266e1254"
+                    client_sid:
+                      type: string
+                      format: uuid
+                      example: "f8d264b7-c26d-4829-be15-299e97b4ba8a"
+                    username:
+                      type: string
+                      example: "1234"
+                    password:
+                      type: string
+                      example: "sxxxxxxxxxx"
+                      description: in the response the password will only show the first character with subsequnet ones replaces by an x
+                    is_active:
+                      type: number
+                      example: 1
+                      default: 1
+                      enum:
+                        - 1
+                        - 0
+                    allow_direct_app_calling:
+                      type: number
+                      example: 1
+                      default: 1
+                      enum:
+                        - 1
+                        - 0
+                    allow_direct_queue_calling:
+                      type: number
+                      example: 1
+                      default: 1
+                      enum:
+                        - 1
+                        - 0
+                    allow_direct_user_calling:
+                      type: number
+                      example: 1
+                      default: 1
+                      enum:
+                        - 1
+                        - 0
+    post:
+      summary: Create a new client
+      description: Creates a new sip client
+      operationId: createClient
+      tags:
+        - Clients
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - account_sid
+                - username
+                - password
+              properties:
+                account_sid:
+                  type: string
+                  format: uuid
+                  example: "9d26a637-1679-471f-8da8-7150266e1254"
+                username:
+                  type: string
+                  example: "1234"
+                password:
+                  type: string
+                  example: "secure_password_123"
+                is_active:
+                  type: number
+                  example: 1
+                  default: 1
+                  enum:
+                    - 1
+                    - 0
+                allow_direct_app_calling:
+                  type: number
+                  example: 1
+                  default: 1
+                  enum:
+                    - 1
+                    - 0
+                allow_direct_queue_calling:
+                  type: number
+                  example: 1
+                  default: 1
+                  enum:
+                    - 1
+                    - 0
+                allow_direct_user_calling:
+                  type: number
+                  example: 1
+                  default: 1
+                  enum:
+                    - 1
+                    - 0
+      responses:
+        "201":
+          description: Client created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sid:
+                    type: string
+                    format: uuid
+              example:
+                sid: "a691e220-80cd-4949-829b-2033e135e30a"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  msg:
+                    type: string
+                    format: text
+              example:
+                msg: "the client's username already exists"
+  /Clients/{ClientSid}:
+    parameters:
+      - name: ClientSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    get:
+      summary: Get a client
+      description: Get details of a single client
+      operationId: getClient
+      tags:
+        - Clients
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: details of a client
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  account_sid:
+                    type: string
+                    format: uuid
+                    example: "9d26a637-1679-471f-8da8-7150266e1254"
+                  client_sid:
+                    type: string
+                    format: uuid
+                    example: "f8d264b7-c26d-4829-be15-299e97b4ba8a"
+                  username:
+                    type: string
+                    example: "1234"
+                  password:
+                    type: string
+                    example: "sxxxxxxxxxx"
+                    description: in the response the password will only show the first character with subsequnet ones replaces by an x
+                  is_active:
+                    type: number
+                    example: 1
+                    default: 1
+                    enum:
+                      - 1
+                      - 0
+                  allow_direct_app_calling:
+                    type: number
+                    example: 1
+                    default: 1
+                    enum:
+                      - 1
+                      - 0
+                  allow_direct_queue_calling:
+                    type: number
+                    example: 1
+                    default: 1
+                    enum:
+                      - 1
+                      - 0
+                  allow_direct_user_calling:
+                    type: number
+                    example: 1
+                    default: 1
+                    enum:
+                      - 1
+                      - 0
+    put:
+      summary: Update a client
+      description: Changes properties on an existing client
+      operationId: updateClient
+      tags:
+        - Clients
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - account_sid
+                - username
+                - password
+              properties:
+                is_active:
+                  type: number
+                  example: 1
+                  default: 1
+                  enum:
+                    - 1
+                    - 0
+                allow_direct_app_calling:
+                  type: number
+                  example: 1
+                  default: 1
+                  enum:
+                    - 1
+                    - 0
+                allow_direct_queue_calling:
+                  type: number
+                  example: 1
+                  default: 1
+                  enum:
+                    - 1
+                    - 0
+                allow_direct_user_calling:
+                  type: number
+                  example: 1
+                  default: 1
+                  enum:
+                    - 1
+                    - 0
+      responses:
+        "204":
+          description: Client updated
+        "404":
+          description: ClientSid not found
+    delete:
+      summary: delete a client
+      description: removes an existing client
+      operationId: deleteClient
+      tags:
+        - Clients
+      responses:
+        "204":
+          description: Client deleted
+        "404":
+          description: ClientSid not found
+
+  /Lcrs:
+    post:
+      tags:
+        - Call Routing
+      summary: create a Least Cost Routing
+      operationId: createLcr
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: name or Least Cost Routing
+                  example: twilioLcr
+              required:
+                - name
+      responses:
+        "201":
+          description: Least Cost Routing successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Call Routing
+      summary: list least cost routings
+      operationId: listLeastCostRoutings
+      responses:
+        "200":
+          description: list of least cost routings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Lcr"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Lcrs/{LcrSid}:
+    parameters:
+      - name: LcrSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Call Routing
+      summary: delete a least cost routing
+      operationId: deleteLeastCostRouting
+      responses:
+        "204":
+          description: least cost routing successfully deleted
+        "404":
+          description: least cost routing not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+                example:
+                  msg: a service provider with active accounts can not be deleted
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Call Routing
+      summary: retrieve least cost routing
+      operationId: getLeastCostRouting
+      responses:
+        "200":
+          description: least cost routing found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Lcr"
+        "404":
+          description: least cost routing not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Call Routing
+      summary: update least cost routing
+      operationId: updateLeastCostRouting
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Lcr"
+      responses:
+        "204":
+          description: least cost routing updated
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "404":
+          description: least cost routing not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /Lcrs/{LcrSid}/Routes:
+    parameters:
+      - name: LcrSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    post:
+      tags:
+        - Call Routing
+      summary: Create least cost routing routes and carrier set entries
+      operationId: createLeastCostRoutingRoutesAndCarrierEntries
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LcrRoutes"
+      responses:
+        "204":
+          description: least cost routing routes and carrier set entries created
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "404":
+          description: least cost routing not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Call Routing
+      summary: update least cost routing routes and carrier set entries
+      operationId: updateLeastCostRoutingRoutesAndCarrierEntries
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LcrRoutes"
+      responses:
+        "204":
+          description: least cost routing ruoutes and carrier entries updated
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "404":
+          description: least cost routing not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /LcrRoutes:
+    post:
+      tags:
+        - Call Routing
+      summary: create a Least Cost Routing Routes
+      operationId: createLcrRoutes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/LcrRoute"
+              required:
+                - lcr_sid
+                - regex
+                - priority
+      responses:
+        "201":
+          description: Least Cost Routing Route successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Call Routing
+      summary: list least cost routings routes
+      operationId: listLeastCostRoutingRoutes
+      parameters:
+        - in: query
+          name: lcr_sid
+          schema:
+            type: string
+          required: true
+      responses:
+        "200":
+          description: list of least cost routing routes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/LcrRoute"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /LcrRoutes/{LcrRouteSid}:
+    parameters:
+      - name: LcrRouteSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Call Routing
+      summary: delete a least cost routing route
+      operationId: deleteLeastCostRoutingRoute
+      responses:
+        "204":
+          description: least cost routing route successfully deleted
+        "404":
+          description: least cost routing route not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+                example:
+                  msg: a service provider with active accounts can not be deleted
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Call Routing
+      summary: retrieve least cost routing route
+      operationId: getLeastCostRoutingRoute
+      responses:
+        "200":
+          description: least cost routing route found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LcrRoute"
+        "404":
+          description: least cost routing route not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Call Routing
+      summary: update least cost routing route
+      operationId: updateLeastCostRoutingRoute
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LcrRoute"
+      responses:
+        "204":
+          description: least cost routing route updated
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "404":
+          description: least cost routing route not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /LcrCarrierSetEntries:
+    post:
+      tags:
+        - Call Routing
+      summary: create a Least Cost Routing Carrier Set Entry
+      operationId: createLcrCarrierSetEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/LcrCarrierSetEntry"
+              required:
+                - lcr_route_sid
+                - voip_carrier_sid
+                - priority
+      responses:
+        "201":
+          description: Least Cost Routing Carrier Set Entry successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Call Routing
+      summary: list least cost routings routes
+      operationId: listLeastCostRoutingCarrierSetEntries
+      responses:
+        "200":
+          description: list of least cost routing carrier set entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/LcrCarrierSetEntry"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /LcrCarrierSetEntries/{LcrCarrierSetEntrySid}:
+    parameters:
+      - name: LcrCarrierSetEntrySid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Call Routing
+      summary: delete a least cost routing carrier set entry
+      operationId: deleteLeastCostRoutingCarrierSetEntry
+      responses:
+        "204":
+          description: least cost routing carrier set entry successfully deleted
+        "404":
+          description: least cost routing carrier set entry not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+                example:
+                  msg: a service provider with active accounts can not be deleted
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Call Routing
+      summary: retrieve least cost routing carrier set entry
+      operationId: getLeastCostRoutingCarrierSetEntry
+      responses:
+        "200":
+          description: least cost routing carrier set entry found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LcrCarrierSetEntry"
+        "404":
+          description: least cost routing carrier set entry not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Call Routing
+      summary: update least cost routing carrier set entry
+      operationId: updateLeastCostRoutingCarrierSetEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LcrCarrierSetEntry"
+      responses:
+        "204":
+          description: least cost routing carrier set entry updated
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "404":
+          description: least cost routing carrier set entry not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /GoogleCustomVoices:
+    post:
+      tags:
+        - Speech
+      summary: create a Google custom voice
+      operationId: createGoogleCustomVoice
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/GoogleCustomVoice"
+              required:
+                - speech_credential_sid
+                - name
+                - reported_usage
+                - model
+      responses:
+        "201":
+          description: Least Cost Routing Carrier Set Entry successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Speech
+      parameters:
+        - in: query
+          name: service_provider_sid
+          required: false
+          schema:
+            type: string
+            description: return only the google voice custom operated belong to this service provider
+        - in: query
+          name: account_sid
+          required: false
+          schema:
+            type: string
+            description: return only the google voice custom operated belong to this account_sid
+        - in: query
+          name: speech_credential_sid
+          required: false
+          schema:
+            type: string
+            description: return only the google voice custom operated belong to this speech credential
+      summary: list google custom voices
+      operationId: listGoogleCustomVoices
+      responses:
+        "200":
+          description: list oflist google custom voices
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/GoogleCustomVoice"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /GoogleCustomVoices/{GoogleCustomVoiceSid}:
+    parameters:
+      - name: GoogleCustomVoiceSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Speech
+      summary: delete a google custom voice
+      operationId: deleteGoogleCustomVoice
+      responses:
+        "204":
+          description: google custom voice successfully deleted
+        "404":
+          description: google custom voice not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+                example:
+                  msg: a service provider with active accounts can not be deleted
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Speech
+      summary: retrieve google custom voice
+      operationId: getGoogleCustomVoice
+      responses:
+        "200":
+          description: google custom voice found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GoogleCustomVoice"
+        "404":
+          description: google custom voice not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Speech
+      summary: update google custom voice
+      operationId: updateGoogleCustomVoice
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GoogleCustomVoice"
+      responses:
+        "204":
+          description: google custom voice updated
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "404":
+          description: least cost routing carrier set entry not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /ServiceProviders:
+    post:
+      tags:
+        - Service Providers
+      summary: create service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: createServiceProvider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: service provider name
+                  example: fastcomms
+                description:
+                  type: string
+                root_domain:
+                  type: string
+                  description: root domain for group of accounts that share a registration hook
+                  example: example.com
+                registration_hook:
+                  $ref: "#/components/schemas/Webhook"
+                  description: authentication webhook for registration
+                ms_teams_fqdn:
+                  type: string
+                  description: SBC domain name for Microsoft Teams
+                  example: contoso.com
+              required:
+                - name
+      responses:
+        "201":
+          description: service provider successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Service Providers
+      summary: list service providers
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: listServiceProviders
+      responses:
+        "200":
+          description: list of service providers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ServiceProvider"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /ServiceProviders/{ServiceProviderSid}:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Service Providers
+      summary: delete a service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: deleteServiceProvider
+      responses:
+        "204":
+          description: service provider successfully deleted
+        "404":
+          description: service provider not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Service Providers
+      summary: retrieve service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: getServiceProvider
+      responses:
+        "200":
+          description: service provider found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServiceProvider"
+        "404":
+          description: service provider not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Service Providers
+      summary: update service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: updateServiceProvider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServiceProvider"
+      responses:
+        "204":
+          description: service provider updated
+        "404":
+          description: service provider not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /ServiceProviders/{ServiceProviderSid}/Accounts:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Service Providers
+      summary: get all accounts for a service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: getServiceProviderAccounts
+      responses:
+        "200":
+          description: account listing
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Account"
+        "403":
+          description: unauthorized
+        "404":
+          description: service provider not found
+  /ServiceProviders/{ServiceProviderSid}/VoipCarriers:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Carriers
+      summary: get all carriers availlble to the account
+      operationId: getServiceProviderCarriers
+      responses:
+        "200":
+          description: account listing
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/VoipCarrier"
+        "403":
+          description: unauthorized
+        "404":
+          description: service provider not found
+    post:
+      tags:
+        - Carriers
+      summary: create a carrier as a service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: createCarrierForServiceProvider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VoipCarrier"
+      responses:
+        "201":
+          description: service provider successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "404":
+          description: service provider not found
+  /Accounts/{AccountSid}/VoipCarriers:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Carriers
+      summary: get all carriers for an account
+      operationId: getAccountCarriers
+      responses:
+        "200":
+          description: carrier listing
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                    - $ref: "#/components/schemas/VoipCarrier"
+                    - type: object
+                      properties:
+                        voip_carrier_sid:
+                          type: string
+                          format: uuid
+        "403":
+          description: unauthorized
+        "404":
+          description: service provider not found
+    post:
+      tags:
+        - Carriers
+      summary: create a carrier for an account
+      operationId: createCarrierForAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VoipCarrier"
+      responses:
+        "201":
+          description: service provider successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "404":
+          description: service provider not found
+  /ServiceProviders/{ServiceProviderSid}/PredefinedCarriers/{PredefinedCarrierSid}:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: PredefinedCarrierSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Carriers
+      summary: add a carrier to a service provider using a template
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: createVoipCarrierFromTemplateBySP
+      responses:
+        "201":
+          description: voip carrier successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /ServiceProviders/{ServiceProviderSid}/SpeechCredentials:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Speech
+      summary: create a speech credential for a service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: addSpeechCredentialForSeerviceProvider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpeechCredential"
+      responses:
+        "201":
+          description: speech credential successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "404":
+          description: credential not found
+  /ServiceProviders/{ServiceProviderSid}/SpeechCredentials/{SpeechCredentialSid}:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: SpeechCredentialSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Speech
+      summary: get a specific speech credential
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: getSpeechCredential
+      responses:
+        "200":
+          description: retrieve speech credentials for a specified account
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpeechCredential"
+        "404":
+          description: credential not found
+    put:
+      tags:
+        - Speech
+      summary: update a speech credential
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: updateSpeechCredential
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpeechCredentialUpdate"
+      responses:
+        "204":
+          description: credential successfully updated
+        "404":
+          description: credential not found
+        "422":
+          description: credential not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    delete:
+      tags:
+        - Speech
+      summary: delete a speech credential
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: deleteSpeechCredential
+      responses:
+        "204":
+          description: credential successfully deleted
+        "404":
+          description: credential not found
+  /ServiceProviders/{ServiceProviderSid}/SpeechCredentials/speech/supportedLanguagesAndVoices:
+    get:
+      tags:
+        - Speech
+      summary: get supported languages, voices and models
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: supportedLanguagesAndVoices
+      parameters:
+        - name: ServiceProviderSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: vendor
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: label
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: get supported languages, voices and models
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpeechLanguagesVoices"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /ServiceProviders/{ServiceProviderSid}/SpeechCredentials/{SpeechCredentialSid}/test:
+    get:
+      tags:
+        - Speech
+      summary: test a speech credential
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: testSpeechCredential
+      parameters:
+        - name: ServiceProviderSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: SpeechCredentialSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: credential test results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tts:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum:
+                          - success
+                          - fail
+                          - not tested
+                      reason:
+                        type: string
+                  stt:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum:
+                          - success
+                          - fail
+                      reason:
+                        type: string
+        "404":
+          description: credential not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /ServiceProviders/{ServiceProviderSid}/Limits:
+    post:
+      tags:
+        - Service Providers
+      summary: create a limit for a service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: addLimitForServiceProvider
+      parameters:
+        - name: ServiceProviderSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Limits"
+      responses:
+        "201":
+          description: limit successfully created or updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "404":
+          description: service provider not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Service Providers
+      summary: retrieve call capacity and other limits from the service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: getServiceProviderLimits
+      parameters:
+        - name: ServiceProviderSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: service provider limits
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Limits"
+        "404":
+          description: service provider not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /ServiceProviders/{ServiceProviderSid}/RecentCalls/{CallId}/pcap:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: CallId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Recent Calls
+      summary: retrieve pcap for a call
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: getRecentCallTraceBySP
+      responses:
+        "200":
+          description: retrieve sip trace data
+          content:
+            application/octet-stream:
+              schema:
+                type: object
+        "404":
+          description: account or call not found
+  /ServiceProviders/{ServiceProviderSid}/RecentCalls:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: page
+        required: true
+        schema:
+          type: integer
+          description: page number of data to retrieve
+      - in: query
+        name: count
+        required: true
+        schema:
+          type: integer
+          description: number of rows to retrieve in each page set
+      - in: query
+        name: days
+        required: false
+        schema:
+          type: integer
+          description: number of days back to retrieve, must be ge 1 and le 30
+      - in: query
+        name: start
+        required: false
+        schema:
+          type: string
+          format: date-time
+          description: start date to retrieve
+      - in: query
+        name: end
+        required: false
+        schema:
+          type: string
+          format: date-time
+          description: end date to retrieve
+      - in: query
+        name: answered
+        required: false
+        schema:
+          type: string
+          enum:
+            - "true"
+            - "false"
+          description: retrieve only answered calls
+      - in: query
+        name: direction
+        required: false
+        schema:
+          type: string
+          enum:
+            - inbound
+            - outbound
+      - in: query
+        name: from
+        required: false
+        schema:
+          type: string
+        description: calling number to retrieve
+      - in: query
+        name: to
+        required: false
+        schema:
+          type: string
+        description: called number to retrieve
+    get:
+      tags:
+        - Recent Calls
+      summary: retrieve recent calls for an account
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: listRecentCallsBySP
+      responses:
+        "200":
+          description: retrieve recent call records for a specified account
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    description: total number of records in that database that match the filter criteria
+                  batch:
+                    type: integer
+                    description: total number of records returned in this page set
+                  page:
+                    type: integer
+                    description: page number that was requested, and is being returned
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        service_provider_sid:
+                          type: string
+                          format: uuid
+                        account_sid:
+                          type: string
+                          format: uuid
+                        call_sid:
+                          type: string
+                          format: uuid
+                        from:
+                          type: string
+                        to:
+                          type: string
+                        answered:
+                          type: boolean
+                        sip_call_id:
+                          type: string
+                        sip_status:
+                          type: integer
+                        duration:
+                          type: integer
+                        attempted_at:
+                          type: integer
+                        answered_at:
+                          type: integer
+                        terminated_at:
+                          type: integer
+                        termination_reason:
+                          type: string
+                        host:
+                          type: string
+                        remote_host:
+                          type: string
+                        direction:
+                          type: string
+                          enum:
+                            - inbound
+                            - outbound
+                        trunk:
+                          type: string
+                      required:
+                        - account_sid
+                        - call_sid
+                        - attempted_at
+                        - terminated_at
+                        - answered
+                        - direction
+                        - from
+                        - to
+                        - sip_status
+                        - duration
+        "404":
+          description: account not found
+  /ServiceProviders/{ServiceProviderSid}/RecentCalls/trace/{CallId}:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: CallId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Recent Calls
+      summary: retrieve jaeger trace detail for a call
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: getRecentCallTraceByCallId
+      responses:
+        "200":
+          description: retrieve trace data
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: service provider or call not found
+  /ServiceProviders/{ServiceProviderSid}/Lcrs:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Call Routing
+      summary: get all Least Cost Routings for a service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: getServiceProviderLcrs
+      responses:
+        "200":
+          description: Least cost routing listing
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Lcr"
+        "403":
+          description: unauthorized
+        "404":
+          description: service provider not found
+    post:
+      tags:
+        - Call Routing
+      summary: create a Lest cost routing for a service provider
+      description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+      operationId: createLcrForServiceProvider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: name or Least Cost Routing
+                  example: twilioLcr
+              required:
+                - name
+      responses:
+        "201":
+          description: service provider Lcr successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "404":
+          description: service provider not found
+  /MicrosoftTeamsTenants:
+    post:
+      tags:
+        - Settings
+      summary: provision a customer tenant for MS Teams
+      operationId: createMsTeamsTenant
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                service_provider_sid:
+                  type: string
+                  format: uuid
+                  example: 85f9c036-ba61-4f28-b2f5-617c23fa68ff
+                account_sid:
+                  type: string
+                  format: uuid
+                  example: 85f9c036-ba61-4f28-b2f5-617c23fa68ff
+                application_sid:
+                  type: string
+                  format: uuid
+                  example: 85f9c036-ba61-4f28-b2f5-617c23fa68ff
+                tenant_fqdn:
+                  type: string
+                  example: customer.contoso.com
+              required:
+                - service_provider_sid
+                - account
+                - tenant_fqdn
+      responses:
+        "201":
+          description: tenant successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessfulAdd"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Settings
+      summary: list MS Teams tenants
+      operationId: listMsTeamsTenants
+      responses:
+        "200":
+          description: list of tenants
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/MsTeamsTenant"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+  /MicrosoftTeamsTenants/{TenantSid}:
+    parameters:
+      - name: TenantSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    delete:
+      tags:
+        - Settings
+      summary: delete an MS Teams tenant
+      operationId: deleteTenant
+      responses:
+        "204":
+          description: tenant successfully deleted
+        "404":
+          description: tenant not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    get:
+      tags:
+        - Settings
+      summary: retrieve an MS Teams tenant
+      operationId: getTenant
+      responses:
+        "200":
+          description: tenant found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MsTeamsTenant"
+        "404":
+          description: account not found
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+    put:
+      tags:
+        - Settings
+      summary: update an MS Teams tenant
+      operationId: putTenant
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MsTeamsTenant"
+      responses:
+        "204":
+          description: tenant updated
+        "404":
+          description: tenant not found
+        "422":
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+        "500":
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+                /ServiceProviders/{ServiceProviderSid}/Alerts:
+                  parameters:
+                    - name: ServiceProviderSid
+                      in: path
+                      required: true
+                      schema:
+                        type: string
+                        format: uuid
+                    - in: query
+                      name: page
+                      required: true
+                      schema:
+                        type: integer
+                        description: page number of data to retrieve
+                    - in: query
+                      name: count
+                      required: true
+                      schema:
+                        type: integer
+                        description: number of rows to retrieve in each page set
+                    - in: query
+                      name: days
+                      required: false
+                      schema:
+                        type: integer
+                        description: number of days back to retrieve, must be ge 1 and le 30
+                    - in: query
+                      name: start
+                      required: false
+                      schema:
+                        type: string
+                        format: date-time
+                        description: start date to retrieve
+                    - in: query
+                      name: end
+                      required: false
+                      schema:
+                        type: string
+                        format: date-time
+                        description: end date to retrieve
+                    - in: query
+                      name: alert_type
+                      required: false
+                      schema:
+                        type: string
+                        enum:
+                          - webhook-failure
+                          - webhook-connection-failure
+                          - webhook-auth-failure
+                          - no-tts
+                          - no-stt
+                          - tts-failure
+                          - stt-failure
+                          - no-carrier
+                          - call-limit
+                          - device-limit
+                          - api-limit
+                  get:
+                    tags:
+                      - Recent Calls
+                    summary: retrieve alerts for a service provider
+                    description: <Error>This endpoint is only availble with an Admin or Service Provider API key</Error>
+                    operationId: listAlerts
+                    responses:
+                      "200":
+                        description: retrieve alerts for a specified account
+                        content:
+                          application/json:
+                            schema:
+                              type: object
+                              properties:
+                                total:
+                                  type: integer
+                                  description: total number of records in that database that match the filter criteria
+                                batch:
+                                  type: integer
+                                  description: total number of records returned in this page set
+                                page:
+                                  type: integer
+                                  description: page number that was requested, and is being returned
+                                data:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      time:
+                                        type: string
+                                        format: date-time
+                                      service_provider_sid:
+                                        type: string
+                                        format: uuid
+                                      account_sid:
+                                        type: string
+                                        format: uuid
+                                      alert_type:
+                                        type: string
+                                      message:
+                                        type: string
+                                      detail:
+                                        type: string
+                                    required:
+                                      - time
+                                      - account_sid
+                                      - alert_type
+                                      - message
+                      "404":
+                        description: service provider not found
+  /AppEnv:
+    get:
+      summary: Get App Env Schema
+      operationId: getAppEnvSchema
+      tags:
+        - Applications
+      parameters:
+        - name: url
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: App Env Schema
+          content:
+            application/json:
+              schema:
+                type: object
+        "204":
+          description: No App Env Schema was found at the url
+        "400":
+          description: The App Env Schma that was returned was invalid
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: token
+  schemas:
+    SuccessfulLogin:
+      type: object
+      required:
+        - username
+        - password
+      properties:
+        token:
+          type: string
+        user_sid:
+          type: string
+        scope:
+          type: string
+        force_change:
+          type: boolean
+    Login:
+      type: object
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+      required:
+        - username
+        - password
+    SuccessfulApiKeyAdd:
+      type: object
+      required:
+        - sid
+        - token
+      properties:
+        sid:
+          type: string
+        token:
+          type: string
+      example:
+        sid: 9d26a637-1679-471f-8da8-7150266e1254
+        token: 589cead6-de24-4689-8ac3-08ffaf102811
+    SuccessfulAdd:
+      type: object
+      required:
+        - sid
+      properties:
+        sid:
+          type: string
+      example:
+        sid: 9d26a637-1679-471f-8da8-7150266e1254
+    GeneralError:
+      type: object
+      required:
+        - msg
+      properties:
+        msg:
+          type: string
+      example:
+        msg: specific error detail will be provided here
+    ServiceProvider:
+      type: object
+      properties:
+        service_provider_sid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        root_domain:
+          type: string
+        registration_hook:
+          $ref: "#/components/schemas/Webhook"
+          description: authentication webhook for registration
+        ms_teams_fqdn:
+          type: string
+        test_number:
+          type: string
+          description: used for inbound testing for accounts on free plan
+        test_application_name:
+          type: string
+          description: name of test application that can be used for new signups
+        test_application_sid:
+          type: string
+          description: identifies test application that can be used for new signups
+      required:
+        - service_provider_sid
+        - name
+    VoipCarrier:
+      type: object
+      properties:
+        service_provider_sid:
+          type: string
+          format: uuid
+          example: 6072f617-6151-4c15-8eb9-74a4967ab701
+        name:
+          type: string
+          example: my carrier
+        description:
+          type: string
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+        e164_leading_plus:
+          type: boolean
+        requires_register:
+          type: boolean
+        register_username:
+          type: string
+        register_sip_realm:
+          type: string
+        register_password:
+          type: string
+        tech_prefix:
+          type: string
+        diversion:
+          type: string
+        is_active:
+          type: boolean
+        smpp_system_id:
+          type: string
+        smpp_password:
+          type: string
+        smpp_inbound_system_id:
+          type: string
+        smpp_inbound_password:
+          type: string
+        smpp_enquire_link_interval:
+          type: integer
+        trunk_type:
+          type: string
+          enum:
+            - static_ip
+            - auth
+            - reg
+          default: static_ip
+          description: The type of trunk to create, see the [guide](/guides/using-the-jambonz-portal/basic-concepts/creating-carriers) for details
+        inbound_auth_username:
+          type: string
+          maxLength: 64
+          description: username for an auth trunk
+        inbound_auth_password:
+          type: string
+          maxLength: 64
+          description: password for an auth trunk
+      required:
+        - service_provider_sid
+        - name
+    SipGateway:
+      type: object
+      properties:
+        sip_gateway_sid:
+          type: string
+          format: uuid
+        ipv4:
+          type: string
+        port:
+          type: integer
+        netmask:
+          type: integer
+        voip_carrier_sid:
+          type: string
+          format: uuid
+        inbound:
+          type: boolean
+        outbound:
+          type: boolean
+      required:
+        - sip_gateway_sid
+        - voip_carrier_sid
+        - ipv4
+        - port
+        - netmask
+    SmppGateway:
+      type: object
+      properties:
+        smpp_gateway_sid:
+          type: string
+          format: uuid
+        ipv4:
+          type: string
+        port:
+          type: integer
+        netmask:
+          type: integer
+        voip_carrier_sid:
+          type: string
+          format: uuid
+        is_primary:
+          type: boolean
+        use_tls:
+          type: boolean
+        inbound:
+          type: boolean
+        outbound:
+          type: boolean
+      required:
+        - smpp_gateway_sid
+        - voip_carrier_sid
+        - ipv4
+        - port
+        - netmask
+    Account:
+      type: object
+      properties:
+        account_sid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        sip_realm:
+          type: string
+        registration_hook:
+          $ref: "#/components/schemas/Webhook"
+          description: authentication webhook for registration
+        device_calling_application_sid:
+          type: string
+          format: uuid
+        service_provider_sid:
+          type: string
+          format: uuid
+        record_all_calls:
+          type: boolean
+        record_format:
+          type: string
+          enum:
+            - wav
+            - mp3
+        bucket_credential:
+          type: object
+          description: Credentials for recording storage
+          properties:
+            vendor:
+              type: string
+              enum:
+                - aws_s3
+                - s3_compatible
+                - azure
+                - google
+            region:
+              type: string
+            name:
+              type: string
+              description: name of the bucket
+            access_key_id:
+              type: string
+            secret_access_key:
+              type: string
+      required:
+        - account_sid
+        - name
+        - service_provider_sid
+    Application:
+      type: object
+      properties:
+        application_sid:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+        account_sid:
+          type: string
+          format: uuid
+        call_hook:
+          $ref: "#/components/schemas/Webhook"
+          description: application webhook for inbound voice calls
+        call_status_hook:
+          $ref: "#/components/schemas/Webhook"
+          description: webhhok for reporting call status events
+        messaging_hook:
+          $ref: "#/components/schemas/Webhook"
+          description: application webhook for inbound SMS/MMS
+        speech_synthesis_vendor:
+          type: string
+        speech_synthesis_voice:
+          type: string
+        speech_recognizer_vendor:
+          type: string
+        speech_recognizer_language:
+          type: string
+        env_vars:
+          type: object
+          description: Object containing the Application Environment Variables as key/value to be sent with the call_hook payload
+        record_all_calls:
+          type: boolean
+      required:
+        - name
+        - account_sid
+    ApiKey:
+      type: object
+      properties:
+        api_key_sid:
+          type: string
+          format: uuid
+        token:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        service_provider_sid:
+          type: string
+          format: uuid
+        expires_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        last_used:
+          type: string
+          format: date-time
+      required:
+        - api_key_sid
+        - token
+    PhoneNumber:
+      type: object
+      properties:
+        phone_number_sid:
+          type: string
+          format: uuid
+        number:
+          type: string
+        voip_carrier_sid:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+      required:
+        - phone_number_sid
+        - number
+        - voip_carrier_sid
+    Registration:
+      type: object
+      properties:
+        registration_sid:
+          type: string
+          format: uuid
+        username:
+          type: string
+        domain:
+          type: string
+        sip_contact:
+          type: string
+        sip_user_agent:
+          type: string
+      required:
+        - registration_sid
+        - username
+        - domain
+        - sip_contact
+    Webhook:
+      type: object
+      properties:
+        webhook_sid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          format: url
+        method:
+          type: string
+          enum:
+            - get
+            - post
+        username:
+          type: string
+        password:
+          type: string
+      required:
+        - url
+      example:
+        url: https://acme.com
+        method: POST
+    MsTeamsTenant:
+      type: object
+      properties:
+        service_provider_sid:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+        tenant_fqdn:
+          type: string
+      required:
+        - service_provider_sid
+        - tenant_fqdn
+    Call:
+      type: object
+      properties:
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+        call_id:
+          type: string
+        call_sid:
+          type: string
+          format: uuid
+        call_status:
+          type: string
+          enum:
+            - trying
+            - ringing
+            - alerting
+            - in-progress
+            - completed
+            - busy
+            - no-answer
+            - failed
+            - queued
+        caller_name:
+          type: string
+        direction:
+          type: string
+          enum:
+            - inbound
+            - outbound
+        duration:
+          type: integer
+        from:
+          type: string
+        originating_sip_trunk_name:
+          type: string
+        parent_call_sid:
+          type: string
+          format: uuid
+        service_url:
+          type: string
+        sip_status:
+          type: integer
+        to:
+          type: string
+      required:
+        - account_sid
+        - call_id
+        - call_sid
+        - call_status
+        - direction
+        - from
+        - service_url
+        - sip_status
+        - to
+    Target:
+      properties:
+        type:
+          type: string
+          enum:
+            - phone
+            - sip
+            - user
+            - teams
+        number:
+          type: string
+        sipUri:
+          type: string
+        tenant:
+          type: string
+          description: Microsoft Teams customer tenant domain name
+        trunk:
+          type: string
+        vmail:
+          type: boolean
+          description: Dial directly into user's voicemail to leave a message
+        overrideTo:
+          type: string
+        name:
+          type: string
+        auth:
+          type: object
+          properties:
+            username:
+              type: string
+            password:
+              type: string
+      required:
+        - type
+      example:
+        type: phone
+        number: "+16172375080"
+    Message:
+      properties:
+        provider:
+          type: string
+        from:
+          type: string
+        to:
+          type: string
+        text:
+          type: string
+        media:
+          type: string
+      required:
+        - from
+        - to
+      example:
+        from: "13394445678"
+        to: "16173333456"
+        text: please call when you can
+    SpeechCredential:
+      properties:
+        speech_credential_sid:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        vendor:
+          type: string
+          enum:
+            - google
+            - aws
+        service_key:
+          type: string
+        access_key_id:
+          type: string
+        secret_access_key:
+          type: string
+        aws_region:
+          type: string
+        last_used:
+          type: string
+          format: date-time
+        last_tested:
+          type: string
+          format: date-time
+        use_for_tts:
+          type: boolean
+        use_for_stt:
+          type: boolean
+        tts_tested_ok:
+          type: boolean
+        stt_tested_ok:
+          type: boolean
+        riva_server_uri:
+          type: string
+    SpeechCredentialUpdate:
+      properties:
+        use_for_tts:
+          type: boolean
+        use_for_stt:
+          type: boolean
+    UserAndAccountDetail:
+      type: object
+      properties:
+        user:
+          type: object
+          properties:
+            user_sid:
+              type: string
+            name:
+              type: string
+            email:
+              type: string
+            phone:
+              type: string
+            service_provider_sid:
+              type: string
+            force_change:
+              type: boolean
+            provider:
+              type: string
+            provider_userid:
+              type: string
+            scope:
+              type: string
+            email_validated:
+              type: boolean
+            phone_validated:
+              type: string
+        account:
+          type: object
+          properties:
+            account_sid:
+              type: string
+            sip_realm:
+              type: string
+            service_provider_sid:
+              type: string
+            registration_hook_sid:
+              type: string
+            queue_event_hook_sid:
+              type: string
+            device_calling_application_sid:
+              type: string
+            is_active:
+              type: boolean
+            created_at:
+              type: string
+              format: date-time
+        testapp:
+          type: object
+          properties:
+            application_sid:
+              type: string
+            name:
+              type: string
+            service_provider_sid:
+              type: string
+            account_sid:
+              type: string
+            call_hook_sid:
+              type: string
+            call_status_hook_sid:
+              type: string
+            messaging_hook_sid:
+              type: string
+            speech_synthesis_vendor:
+              type: string
+            speech_synthesis_language:
+              type: string
+            speech_synthesis_voice:
+              type: string
+            speech_recognizer_vendor:
+              type: string
+            speech_recognizer_language:
+              type: string
+        balance:
+          type: object
+          properties:
+            currency:
+              type: string
+              enum:
+                - USD
+                - EUR
+            balance:
+              type: integer
+            last_updated_at:
+              type: string
+              format: date-time
+            created_at:
+              type: string
+              format: date-time
+            last_transaction_id:
+              type: string
+        capacities:
+          type: object
+          properties:
+            effective_start_date:
+              type: string
+              format: date-time
+            effective_end_date:
+              type: string
+              format: date-time
+            limit_sessions:
+              type: integer
+            limit_registrations:
+              type: integer
+        api_keys:
+          type: array
+          items:
+            type: object
+            properties:
+              token:
+                type: string
+              last_used:
+                type: string
+                format: date-time
+              created_at:
+                type: string
+                format: date-time
+        products:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+              category:
+                type: string
+              quantity:
+                type: string
+              in_starter_set:
+                type: boolean
+              product_sid:
+                type: string
+              effective_start_date:
+                type: string
+                format: date-time
+              effective_end_date:
+                type: string
+                format: date-time
+    UserProfile:
+      type: object
+      properties:
+        user_sid:
+          type: string
+          example: a5bce31e-a028-45cd-94c4-f121b72fec61
+        account_sid:
+          type: string
+          example: a5bce31e-a028-45cd-94c4-f121b72fec61
+        is_active:
+          type: boolean
+          description: indicates whether account is active
+          example: true
+        name:
+          type: string
+          description: full user name
+          example: Dave Horton
+        email:
+          type: string
+          description: email associated with user
+          example: daveh@drachtio.org
+        phone:
+          type: string
+          description: phone associated with user
+        provider:
+          type: string
+          description: authentication provider
+          enum:
+            - github
+            - google
+            - local
+          example: github
+        scope:
+          type: string
+          description: scope of user permissions
+          enum:
+            - read-only
+            - read-write
+          example: read-write
+        pristine:
+          type: boolean
+          description: true if account was newly created
+          example: true
+        email_validated:
+          type: boolean
+          description: indicates whether user has validated their email address
+          example: true
+        phone_validated:
+          type: boolean
+          description: indicates whether user has validated their mobile phone
+          example: true
+        tutorial_completion:
+          type: integer
+          description: bitmask indicating which tutorials have been completed
+          example: 1
+        jwt:
+          type: string
+          description: json web token to be used as bearer token in API requests
+      required:
+        - user_sid
+        - provider
+        - name
+        - email
+        - scope
+        - account_validated
+        - pristine
+        - jwt
+        - is_active
+    Charge:
+      type: object
+      properties:
+        charge_sid:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+        billed_at:
+          type: string
+          format: date-time
+        billed_activity:
+          type: string
+          enum:
+            - inbound-call
+            - outbound-call
+            - inbound-sms
+            - outbound-sms
+            - inbound-mms
+            - outbound-mms
+            - tts
+            - stt
+        call_billing_record_sid:
+          type: string
+          format: uuid
+        message_record_sid:
+          type: string
+          format: uuid
+        call_secs_billed:
+          type: integer
+        tts_chars_billed:
+          type: integer
+        stt_secs_billed:
+          type: integer
+        amount_charged:
+          type: integer
+          format: double
+      required:
+        - account_sid
+        - billed_activity
+        - amount_charged
+    RecentCalls:
+      type: object
+      properties:
+        account_sid:
+          type: string
+          format: uuid
+        call_sid:
+          type: string
+          format: uuid
+        from:
+          type: string
+        to:
+          type: string
+        answered:
+          type: boolean
+        sip_call_id:
+          type: string
+        sip_status:
+          type: integer
+        duration:
+          type: integer
+        attempted_at:
+          type: integer
+        answered_at:
+          type: integer
+        terminated_at:
+          type: integer
+        termination_reason:
+          type: string
+        host:
+          type: string
+        remote_host:
+          type: string
+        direction:
+          type: string
+          enum:
+            - inbound
+            - outbound
+        trunk:
+          type: string
+      required:
+        - account_sid
+        - call_sid
+        - attempted_at
+        - terminated_at
+        - answered
+        - direction
+        - from
+        - to
+        - sip_status
+        - duration
+    Alert:
+      type: object
+      properties:
+        alert_sid:
+          type: string
+          format: uuid
+        call_sid:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+        occurred_at:
+          type: string
+          format: date-time
+        alert_type:
+          type: string
+          enum:
+            - webhook-failed
+            - bad-application-syntax
+            - speech-operation-failed
+            - limit-exceeded
+        details:
+          type: string
+      required:
+        - alert_sid
+        - account_sid
+        - occurred_at
+        - alert_type
+    Product:
+      type: object
+      properties:
+        product_sid:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        unit_label:
+          type: string
+        category:
+          type: string
+      required:
+        - product_sid
+        - name
+        - unit_label
+        - category
+    PredefinedCarrier:
+      type: object
+      properties:
+        predefined_carrier_sid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        requires_static_ip:
+          type: boolean
+        e164_leading_plus:
+          type: boolean
+        requires_register:
+          type: boolean
+        register_username:
+          type: string
+        register_sip_realm:
+          type: string
+        register_password:
+          type: string
+        register_from_user:
+          type: string
+        register_from_domain:
+          type: string
+        register_public_ip_in_contact:
+          type: boolean
+        tech_prefix:
+          type: string
+        inbound_auth_username:
+          type: string
+        inbound_auth_password:
+          type: string
+        diversion:
+          type: string
+      required:
+        - predefined_carrier_sid
+        - name
+        - requires_static_ip
+        - e164_leading_plus
+        - requires_register
+    Limits:
+      type: object
+      properties:
+        category:
+          type: string
+          enum:
+            - voice_call_session
+            - api_limit
+            - devices
+    Lcr:
+      type: object
+      properties:
+        name:
+          type: string
+          example: twilioLcr
+        default_carrier_set_entry_sid:
+          type: string
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+      required:
+        - name
+    LcrRoute:
+      type: object
+      properties:
+        lcr_sid:
+          type: string
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        regex:
+          type: string
+          description: out going call Phone number regex
+          example: 1*
+        priority:
+          type: integer
+          example: 1
+        description:
+          type: string
+          example: this is example description
+      required:
+        - lcr_sid
+        - regex
+        - priority
+    LcrCarrierSetEntry:
+      type: object
+      properties:
+        workload:
+          type: integer
+          example: 90
+          description: traffic distribution value
+        lcr_route_sid:
+          type: string
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        voip_carrier_sid:
+          type: string
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        priority:
+          type: integer
+          example: 1
+      required:
+        - lcr_route_sid
+        - voip_carrier_sid
+        - priority
+    LcrRouteAndCarrierEntries:
+      allOf:
+        - $ref: "#/components/schemas/LcrRoute"
+        - type: object
+          properties:
+            lcr_carrier_set_entries:
+              type: array
+              items:
+                $ref: "#/components/schemas/LcrCarrierSetEntry"
+    LcrRoutes:
+      type: array
+      items:
+        $ref: "#/components/schemas/LcrRouteAndCarrierEntries"
+    GoogleCustomVoice:
+      type: object
+      properties:
+        speech_credential_sid:
+          type: string
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        name:
+          type: string
+          example: Sally
+        reported_usage:
+          type: string
+          example: REALTIME
+        model:
+          type: string
+          example: projects/12412312/locations/global/models/2134124123-2dbf-43be-9593-12314123
+      required:
+        - speech_credential_sid
+        - name
+        - reported_usage
+        - model
+    RegisteredClient:
+      type: object
+      properties:
+        name:
+          type: string
+          example: xhoaluu
+          description: the client username
+        contact:
+          type: string
+          example: sip:0dluqjt6@od41sl9jfc9m.invalid;transport=ws
+          description: The value in the contact header of the registration
+        expiryTime:
+          type: integer
+          example: 1698981449173
+          description: The timestamp (in ms since 00:00:00.000 01/01/1970) that the current registraion will expire
+        protocol:
+          type: string
+          enum:
+            - wss
+            - udp
+            - tcp
+            - tls
+        allow_direct_app_calling:
+          type: integer
+          example: 1
+          description: set to 1 if client is allowed to call app sids directly
+        allow_direct_queue_calling:
+          type: integer
+          example: 1
+          description: set to 1 if client is allowed to dial into queues to dequeue calls
+        allow_direct_user_calling:
+          type: integer
+          example: 1
+          description: set to 1 if client is allowed to call other users by name directly.
+        registered_status:
+          type: string
+          enum:
+            - active
+            - inactive
+          description: if there is a current registered session from the client
+        proxy:
+          type: string
+          example: sip:192.0.0.1:12345
+          description: The source IP and Port used for the registration request.
+    TtsModel:
+      type: object
+      properties:
+        name:
+          type: string
+          example: Turbo v2
+        value:
+          type: string
+          example: eleven_turbo_v2
+    LanguageVoice:
+      type: object
+      properties:
+        name:
+          type: string
+          example: Standard-A (Female)
+        value:
+          type: string
+          example: ar-XA-Standard-A
+    LanguageVoices:
+      type: object
+      properties:
+        name:
+          type: string
+          example: English (US)
+        value:
+          type: string
+          example: en-US
+        voices:
+          type: array
+          items:
+            $ref: "#/components/schemas/LanguageVoice"
+    SpeechLanguagesVoices:
+      type: object
+      properties:
+        tts:
+          type: array
+          items:
+            $ref: "#/components/schemas/LanguageVoices"
+        stt:
+          type: array
+          items:
+            $ref: "#/components/schemas/LanguageVoice"
+        ttsModel:
+          type: array
+          items:
+            $ref: "#/components/schemas/TtsModel"
+    UserList:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        is_active:
+          type: boolean
+        force_change:
+          type: boolean
+        scope:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -1,0 +1,660 @@
+/**
+ * Generates TypeScript type declarations from:
+ * 1. @jambonz/verb-specifications specs - Webhook verb types
+ * 2. calls.yaml + platform.yaml - REST API types (official jambonz API docs)
+ *
+ * Run with: node scripts/generate-types.js
+ *
+ */
+
+const { readFileSync, writeFileSync, mkdirSync, existsSync } = require('fs');
+const { resolve } = require('path');
+const { parse: parseYaml } = require('yaml');
+
+// Load specs from @jambonz/verb-specifications (webhook verbs)
+const { specs } = require('@jambonz/verb-specifications');
+
+// Load OpenAPI specs (REST API) - combine calls.yaml and platform.yaml
+const callsYamlPath = resolve(__dirname, '../schema/calls.yaml');
+const platformYamlPath = resolve(__dirname, '../schema/platform.yaml');
+
+let openapi = null;
+
+function loadAndMergeOpenAPISpecs() {
+  const callsExists = existsSync(callsYamlPath);
+  const platformExists = existsSync(platformYamlPath);
+
+  if (!callsExists && !platformExists) {
+    console.log('⚠ No calls.yaml or platform.yaml found, REST API types will use fallback definitions');
+    return null;
+  }
+
+  // Start with empty merged spec
+  const merged = {
+    openapi: '3.0.0',
+    info: { title: 'Jambonz API', version: '1.0.0' },
+    paths: {},
+    components: { schemas: {} },
+  };
+
+  // Load calls.yaml (Calls API)
+  if (callsExists) {
+    const callsSpec = parseYaml(readFileSync(callsYamlPath, 'utf-8'));
+    console.log('✓ Loaded calls.yaml');
+
+    // Merge paths
+    Object.assign(merged.paths, callsSpec.paths || {});
+
+    // Merge schemas
+    if (callsSpec.components && callsSpec.components.schemas) {
+      Object.assign(merged.components.schemas, callsSpec.components.schemas);
+    }
+  }
+
+  // Load platform.yaml (Platform API - accounts, applications, users, etc.)
+  if (platformExists) {
+    const platformSpec = parseYaml(readFileSync(platformYamlPath, 'utf-8'));
+    console.log('✓ Loaded platform.yaml');
+
+    // Merge paths
+    Object.assign(merged.paths, platformSpec.paths || {});
+
+    // Merge schemas
+    if (platformSpec.components && platformSpec.components.schemas) {
+      Object.assign(merged.components.schemas, platformSpec.components.schemas);
+    }
+  }
+
+  return merged;
+}
+
+openapi = loadAndMergeOpenAPISpecs();
+
+// ============================================
+// Configuration
+// ============================================
+
+// Verbs that are callable methods on WebhookResponse (vs helper types)
+const VERB_NAMES = new Set([
+  'alert', 'answer', 'sip:decline', 'sip:request', 'sip:refer', 'config',
+  'dub', 'dequeue', 'enqueue', 'leave', 'hangup', 'play', 'say', 'gather',
+  'conference', 'dial', 'dialogflow', 'dtmf', 'lex', 'listen', 'stream',
+  'llm', 'message', 'pause', 'rasa', 'redirect', 'rest:dial', 'tag', 'transcribe', 'pipeline'
+]);
+
+// Verbs with optional payloads (can be called with empty object or no args)
+const OPTIONAL_PAYLOAD_VERBS = new Set([
+  'answer', 'config', 'leave', 'hangup', 'say', 'gather', 'transcribe'
+]);
+
+// OpenAPI operations we want to extract for the SDK
+const SDK_OPERATIONS = {
+  // Calls
+  createCall: { method: 'create', class: 'Calls', returns: 'string' },
+  updateCall: { method: 'update', class: 'Calls', returns: 'void' },
+  getCall: { method: 'retrieve', class: 'Calls', returns: 'ApiCall' },
+  listCalls: { method: 'list', class: 'Calls', returns: 'ApiCall[]' },
+  deleteCall: { method: 'delete', class: 'Calls', returns: 'void' },
+  // ------Messages (not yet supported in official docs)-------
+  // createMessage: { method: 'create', class: 'Messages', returns: 'string' },
+  // Applications
+  createApplication: { method: 'create', class: 'Applications', returns: 'string' },
+  updateApplication: { method: 'update', class: 'Applications', returns: 'void' },
+  listApplications: { method: 'list', class: 'Applications', returns: 'ApiApplication[]' },
+  deleteApplication: { method: 'delete', class: 'Applications', returns: 'void' },
+};
+
+// OpenAPI schemas we want to include
+const SDK_SCHEMAS = [
+  'Webhook',
+  'Target',
+  'Call',
+  'Application',
+  // 'Message', // not yet supported in official docs
+  'Account',
+  'VoipCarrier',
+  'SipGateway',
+  'SmppGateway',
+  'PhoneNumber',
+  'SpeechCredential',
+  'ServiceProvider',
+  'Registration',
+  'ApiKey',
+  'amd',
+  'GeneralError',
+];
+
+// Track which types we've generated to handle references
+const generatedTypes = new Set();
+
+// ============================================
+// Utility Functions
+// ============================================
+
+function getSpecsVersion() {
+  try {
+    const pkgPath = resolve(__dirname, '../node_modules/@jambonz/verb-specifications/package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    return pkg.version || 'unknown';
+  } catch (err) {
+    return 'unknown';
+  }
+}
+
+// Convert verb/type name to valid TypeScript interface name
+function toInterfaceName(name) {
+  // Handle names like "sip:decline" -> "SipDecline"
+  // Handle names like "rest:dial" -> "RestDial"
+  // Handle names like "sm_transcriptionConfig" -> "SmTranscriptionConfig"
+  return name
+    .split(/[:\-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+// Convert verb name to method name (for WebhookResponse)
+function toMethodName(name) {
+  // "sip:decline" -> "sip_decline" (as used in the actual SDK)
+  return name.replace(':', '_');
+}
+
+// ============================================
+// specs.json Type Generation (Webhook Verbs)
+// ============================================
+
+function convertSpecsType(propDef, _propName) {
+  // Array of references like ["#target"]
+  if (Array.isArray(propDef)) {
+    const innerType = propDef[0];
+    if (typeof innerType === 'string' && innerType.startsWith('#')) {
+      return `${toInterfaceName(innerType.slice(1))}[]`;
+    }
+    return 'unknown[]';
+  }
+
+  // Object with type and enum
+  if (typeof propDef === 'object' && propDef !== null) {
+    if (propDef.enum) {
+      return propDef.enum.map((v) => `'${v}'`).join(' | ');
+    }
+    if (propDef.type === 'array') {
+      return 'unknown[]';
+    }
+    return convertSpecsSimpleType(propDef.type);
+  }
+
+  // String type definition
+  if (typeof propDef === 'string') {
+    if (propDef.startsWith('#')) {
+      return toInterfaceName(propDef.slice(1));
+    }
+    return convertSpecsSimpleType(propDef);
+  }
+
+  return 'unknown';
+}
+
+function convertSpecsSimpleType(typeStr) {
+  if (typeStr.includes('|')) {
+    return typeStr.split('|').map((t) => convertSpecsSimpleType(t.trim())).join(' | ');
+  }
+
+  switch (typeStr) {
+    case 'string': return 'string';
+    case 'number': return 'number';
+    case 'boolean': return 'boolean';
+    case 'object': return 'Record<string, unknown>';
+    case 'array': return 'unknown[]';
+    default: return 'unknown';
+  }
+}
+
+function generateVerbInterface(name, spec) {
+  const interfaceName = toInterfaceName(name);
+
+  // Skip if already generated
+  if (generatedTypes.has(interfaceName)) {
+    return '';
+  }
+  generatedTypes.add(interfaceName);
+
+  const props = spec.properties || {};
+  const required = new Set(spec.required || []);
+
+  const lines = [];
+  lines.push(`  export interface ${interfaceName} {`);
+
+  for (const [propName, propDef] of Object.entries(props)) {
+    const tsType = convertSpecsType(propDef, propName);
+    const optional = required.has(propName) ? '' : '?';
+    lines.push(`    ${propName}${optional}: ${tsType};`);
+  }
+
+  lines.push('  }');
+  return lines.join('\n');
+}
+
+function generateVerbTypes() {
+  const output = [];
+
+  output.push('  // ============================================');
+  output.push('  // Verb Payload Types (from specs.json)');
+  output.push('  // ============================================');
+  output.push('');
+
+  // Sort to ensure helper types come before types that reference them
+  const sortedSpecs = Object.entries(specs).sort((a, b) => {
+    const aIsVerb = VERB_NAMES.has(a[0]);
+    const bIsVerb = VERB_NAMES.has(b[0]);
+    if (aIsVerb && !bIsVerb) return 1;
+    if (!aIsVerb && bIsVerb) return -1;
+    return a[0].localeCompare(b[0]);
+  });
+
+  for (const [name, spec] of sortedSpecs) {
+    const interfaceCode = generateVerbInterface(name, spec);
+    if (interfaceCode) {
+      output.push(interfaceCode);
+      output.push('');
+    }
+  }
+
+  return output;
+}
+
+// ============================================
+// OpenAPI Type Generation (REST API)
+// ============================================
+
+function resolveRef(ref) {
+  if (!openapi || !ref.startsWith('#/components/schemas/')) {
+    return null;
+  }
+  const schemaName = ref.replace('#/components/schemas/', '');
+  return openapi.components.schemas[schemaName] || null;
+}
+
+function convertOpenAPIType(schema, indent = '    ') {
+  if (schema.$ref) {
+    const refName = schema.$ref.replace('#/components/schemas/', '');
+    // Use Api prefix for schemas that might conflict with verb types
+    if (refName === 'Target') return 'ApiTarget';
+    if (refName === 'Call') return 'ApiCall';
+    if (refName === 'Application') return 'ApiApplication';
+    if (refName === 'Message') return 'ApiMessage';
+    return refName;
+  }
+
+  if (schema.enum) {
+    return schema.enum.map((v) => `'${v}'`).join(' | ');
+  }
+
+  if (schema.allOf) {
+    // Merge all schemas
+    const merged = [];
+    for (const subSchema of schema.allOf) {
+      merged.push(convertOpenAPIType(subSchema, indent));
+    }
+    return merged.join(' & ');
+  }
+
+  if (schema.oneOf || schema.anyOf) {
+    const schemas = schema.oneOf || schema.anyOf || [];
+    return schemas.map((s) => convertOpenAPIType(s, indent)).join(' | ');
+  }
+
+  switch (schema.type) {
+    case 'string':
+      return 'string';
+    case 'number':
+    case 'integer':
+      return 'number';
+    case 'boolean':
+      return 'boolean';
+    case 'array':
+      if (schema.items) {
+        return `${convertOpenAPIType(schema.items, indent)}[]`;
+      }
+      return 'unknown[]';
+    case 'object':
+      if (schema.properties) {
+        return generateInlineObject(schema, indent);
+      }
+      return 'Record<string, unknown>';
+    default:
+      if (schema.properties) {
+        return generateInlineObject(schema, indent);
+      }
+      return 'unknown';
+  }
+}
+
+function generateInlineObject(schema, indent) {
+  const props = schema.properties || {};
+  const required = new Set(schema.required || []);
+  const lines = ['{'];
+  const innerIndent = indent + '  ';
+
+  for (const [propName, propSchema] of Object.entries(props)) {
+    const optional = required.has(propName) ? '' : '?';
+    const propType = convertOpenAPIType(propSchema, innerIndent);
+    if (propSchema.description) {
+      lines.push(`${innerIndent}/** ${propSchema.description} */`);
+    }
+    lines.push(`${innerIndent}${propName}${optional}: ${propType};`);
+  }
+
+  lines.push(`${indent}}`);
+  return lines.join('\n');
+}
+
+function generateOpenAPISchema(name, schema) {
+  const nameMap = {
+    Target: 'ApiTarget',
+    Call: 'ApiCall',
+    Application: 'ApiApplication',
+    Message: 'ApiMessage',
+    amd: 'Amd'
+  };
+  const interfaceName = nameMap[name] || name;
+
+  if (generatedTypes.has(interfaceName)) {
+    return '';
+  }
+  generatedTypes.add(interfaceName);
+
+  const lines = [];
+
+  if (schema.description) {
+    lines.push(`  /** ${schema.description} */`);
+  }
+
+  lines.push(`  export interface ${interfaceName} {`);
+
+  const props = schema.properties || {};
+  const required = new Set(schema.required || []);
+
+  for (const [propName, propSchema] of Object.entries(props)) {
+    const optional = required.has(propName) ? '' : '?';
+    const propType = convertOpenAPIType(propSchema, '    ');
+
+    if (propSchema.description) {
+      lines.push(`    /** ${propSchema.description} */`);
+    }
+    if (propSchema.enum) {
+      lines.push(`    ${propName}${optional}: ${propSchema.enum.map((v) => `'${v}'`).join(' | ')};`);
+    } else {
+      lines.push(`    ${propName}${optional}: ${propType};`);
+    }
+  }
+
+  lines.push('  }');
+  return lines.join('\n');
+}
+
+function generateOperationRequestType(operationId, operation) {
+  if (!operation.requestBody ||
+      !operation.requestBody.content ||
+      !operation.requestBody.content['application/json'] ||
+      !operation.requestBody.content['application/json'].schema) {
+    return '';
+  }
+
+  const schema = operation.requestBody.content['application/json'].schema;
+  const typeName = operationId.charAt(0).toUpperCase() + operationId.slice(1) + 'Options';
+
+  // Check if already generated (don't add here - generateOpenAPISchema will add it)
+  if (generatedTypes.has(typeName)) {
+    return '';
+  }
+
+  // If it's a reference, resolve it
+  if (schema.$ref) {
+    const resolved = resolveRef(schema.$ref);
+    if (resolved) {
+      return generateOpenAPISchema(typeName, resolved);
+    }
+    return '';
+  }
+
+  // Generate inline
+  return generateOpenAPISchema(typeName, schema);
+}
+
+function generateRestApiTypes() {
+  const output = [];
+
+  output.push('  // ============================================');
+  output.push('  // REST API Types (from calls.yaml + platform.yaml)');
+  output.push('  // ============================================');
+  output.push('');
+
+  // Always add JambonzOptions (not in OpenAPI)
+  output.push('  export interface JambonzOptions {');
+  output.push('    baseUrl: string;');
+  output.push('  }');
+  output.push('');
+
+  if (!openapi) {
+    output.push('  // OpenAPI spec not found - using minimal fallback types');
+    output.push('');
+    return output;
+  }
+
+  // Generate schema types
+  for (const schemaName of SDK_SCHEMAS) {
+    const schema = openapi.components.schemas[schemaName];
+    if (schema) {
+      const code = generateOpenAPISchema(schemaName, schema);
+      if (code) {
+        output.push(code);
+        output.push('');
+      }
+    }
+  }
+
+  // Generate operation request types
+  for (const pathItem of Object.values(openapi.paths)) {
+    for (const method of ['get', 'post', 'put', 'delete']) {
+      const operation = pathItem[method];
+      if (operation && operation.operationId && SDK_OPERATIONS[operation.operationId]) {
+        const code = generateOperationRequestType(operation.operationId, operation);
+        if (code) {
+          output.push(code);
+          output.push('');
+        }
+      }
+    }
+  }
+
+  //---- Messaging not yet supported in official docs ----
+  // Fallback: Generate missing operation types from schemas
+  // This handles cases where the operation isn't in the YAML but the schema exists
+  //
+  //
+  // const OPERATION_SCHEMA_FALLBACKS = {
+  //   CreateMessageOptions: 'Message',
+  // };
+
+  // for (const [typeName, schemaName] of Object.entries(OPERATION_SCHEMA_FALLBACKS)) {
+  //   if (!generatedTypes.has(typeName)) {
+  //     const schema = openapi.components.schemas[schemaName];
+  //     if (schema) {
+  //       const code = generateOpenAPISchema(typeName, schema);
+  //       if (code) {
+  //         output.push(code);
+  //         output.push('');
+  //       }
+  //     }
+  //   }
+  // }
+
+  return output;
+}
+
+// ============================================
+// Class Generation
+// ============================================
+
+function generateClasses() {
+  const output = [];
+
+  output.push('  // ============================================');
+  output.push('  // Classes');
+  output.push('  // ============================================');
+  output.push('');
+
+  output.push('  export class Calls {');
+  output.push('    create(opts: CreateCallOptions): Promise<string>;');
+  output.push('    update(callSid: string, opts: UpdateCallOptions): Promise<void>;');
+  output.push('    list(opts?: Record<string, unknown>): Promise<ApiCall[]>;');
+  output.push('    retrieve(callSid: string): Promise<ApiCall>;');
+  output.push('    delete(callSid: string): Promise<void>;');
+  output.push('  }');
+  output.push('');
+
+  // ------Messages class (not yet supported in official docs)------
+  // output.push('  export class Messages {');
+  // output.push('    create(opts: CreateMessageOptions): Promise<string>;');
+  // output.push('  }');
+  // output.push('');
+
+  output.push('  export class Applications {');
+  output.push('    create(opts: CreateApplicationOptions): Promise<string>;');
+  output.push('    update(appSid: string, opts: UpdateApplicationOptions): Promise<void>;');
+  output.push('    list(opts?: Record<string, unknown>): Promise<ApiApplication[]>;');
+  output.push('    retrieve(appSid: string): Promise<ApiApplication>;');
+  output.push('    delete(appSid: string): Promise<void>;');
+  output.push('  }');
+  output.push('');
+
+  output.push('  export class Jambonz {');
+  output.push('    constructor(accountSid: string, apiKey: string, opts: JambonzOptions);');
+  output.push('    calls: Calls;');
+  // output.push('    messages: Messages;'); // not yet supported in official docs
+  output.push('    applications: Applications;');
+  output.push('  }');
+  output.push('');
+
+  return output;
+}
+
+// ============================================
+// WebhookResponse Generation
+// ============================================
+
+function generateWebhookResponse() {
+  const output = [];
+
+  output.push('  export class WebhookResponse {');
+  output.push('    payload: object[];');
+  output.push('    length: number;');
+  output.push('');
+  output.push('    constructor();');
+  output.push('');
+  output.push('    static verifyJambonzSignature(');
+  output.push('      secret: string | string[]');
+  output.push('    ): (req: unknown, res: unknown, next: () => void) => void;');
+  output.push('');
+  output.push('    toJSON(): object[];');
+  output.push('');
+  output.push('    // Verb methods');
+
+  for (const verbName of VERB_NAMES) {
+    if (specs[verbName]) {
+      const methodName = toMethodName(verbName);
+      const typeName = toInterfaceName(verbName);
+      const optional = OPTIONAL_PAYLOAD_VERBS.has(verbName) ? '?' : '';
+      output.push(`    ${methodName}(payload${optional}: ${typeName}): this;`);
+    }
+  }
+
+  output.push('  }');
+  output.push('');
+
+  return output;
+}
+
+// ============================================
+// Exports Generation
+// ============================================
+
+function generateExports() {
+  const output = [];
+
+  output.push('  // ============================================');
+  output.push('  // Exports');
+  output.push('  // ============================================');
+  output.push('');
+  output.push('  // Default export');
+  output.push('  function jambonz(accountSid: string, apiKey: string, opts: JambonzOptions): Jambonz;');
+  output.push('  export default jambonz;');
+  output.push('  export { jambonz };');
+  output.push('');
+
+  return output;
+}
+
+// ============================================
+// Main Generation
+// ============================================
+
+function generateTypes() {
+  const output = [];
+
+  // Header
+  output.push('// Type declarations for @jambonz/node-client');
+  output.push('// Auto-generated from:');
+  output.push(`//   - @jambonz/verb-specifications specs.json (v${getSpecsVersion()}) - Webhook verbs`);
+  output.push('//   - calls.yaml + platform.yaml - REST API types');
+  output.push('//');
+  output.push('// Run: npm run generate-types');
+  output.push(`// Generated: ${new Date().toISOString()}`);
+  output.push('');
+  output.push('declare module "@jambonz/node-client" {');
+  output.push('');
+
+  // Generate verb types from specs.json
+  output.push(...generateVerbTypes());
+
+  // Generate REST API types from OpenAPI
+  output.push(...generateRestApiTypes());
+
+  // Generate classes
+  output.push(...generateClasses());
+
+  // Generate WebhookResponse
+  output.push(...generateWebhookResponse());
+
+  // Generate exports
+  output.push(...generateExports());
+
+  output.push('}');
+
+  return output.join('\n');
+}
+
+// ============================================
+// Main Execution
+// ============================================
+
+function main() {
+  console.log('Generating jambonz types...');
+  console.log(`  specs.json version: ${getSpecsVersion()}`);
+
+  // Ensure types directory exists
+  const typesDir = resolve(__dirname, '../types');
+  mkdirSync(typesDir, { recursive: true });
+
+  // Generate the types
+  const types = generateTypes();
+
+  // Write to output file
+  const outputPath = resolve(typesDir, 'jambonz-node-client.d.ts');
+  writeFileSync(outputPath, types);
+
+  console.log(`✓ Generated ${generatedTypes.size} types`);
+  console.log(`✓ Output: ${outputPath}`);
+}
+
+main();

--- a/types/jambonz-node-client.d.ts
+++ b/types/jambonz-node-client.d.ts
@@ -1,0 +1,1325 @@
+// Type declarations for @jambonz/node-client
+// Auto-generated from:
+//   - @jambonz/verb-specifications specs.json (v0.0.121) - Webhook verbs
+//   - calls.yaml + platform.yaml - REST API types
+//
+// Run: npm run generate-types
+// Generated: 2025-12-22T02:38:48.110Z
+
+declare module "@jambonz/node-client" {
+
+  // ============================================
+  // Verb Payload Types (from specs.json)
+  // ============================================
+
+  export interface ActionHookDelayAction {
+    enabled?: boolean;
+    noResponseTimeout?: number;
+    noResponseGiveUpTimeout?: number;
+    retries?: number;
+    actions?: unknown[];
+    giveUpActions?: unknown[];
+  }
+
+  export interface Amd {
+    actionHook: Record<string, unknown> | string;
+    thresholdWordCount?: number;
+    digitCount?: number;
+    timers?: AmdTimers;
+    recognizer?: Recognizer;
+  }
+
+  export interface AmdTimers {
+    noSpeechTimeoutMs?: number;
+    decisionTimeoutMs?: number;
+    toneTimeoutMs?: number;
+    greetingCompletionTimeoutMs?: number;
+  }
+
+  export interface AssemblyAiOptions {
+    apiKey?: string;
+    serviceVersion?: 'v2' | 'v3';
+    formatTurns?: boolean;
+    endOfTurnConfidenceThreshold?: number;
+    minEndOfTurnSilenceWhenConfident?: number;
+    maxTurnSilence?: number;
+  }
+
+  export interface Auth {
+    username: string;
+    password: string;
+  }
+
+  export interface AwsOptions {
+    accessKey?: string;
+    secretKey?: string;
+    securityToken?: string;
+    region?: string;
+    vocabularyName?: string;
+    vocabularyFilterName?: string;
+    vocabularyFilterMethod?: 'remove' | 'mask' | 'tag';
+    languageModelName?: string;
+    piiEntityTypes?: unknown[];
+    piiIdentifyEntities?: boolean;
+  }
+
+  export interface AzureOptions {
+    speechSegmentationSilenceTimeoutMs?: number;
+    postProcessing?: string;
+    audioLogging?: boolean;
+    languageIdMode?: 'AtStart' | 'Continuous';
+    speechRecognitionMode?: 'CONVERSATION' | 'DICTATION' | 'INTERACTIVE';
+  }
+
+  export interface BargeIn {
+    enable: boolean;
+    sticky?: boolean;
+    actionHook?: Record<string, unknown> | string;
+    partialResultHook?: Record<string, unknown> | string;
+    input?: unknown[];
+    finishOnKey?: string;
+    numDigits?: number;
+    minDigits?: number;
+    maxDigits?: number;
+    interDigitTimeout?: number;
+    dtmfBargein?: boolean;
+    minBargeinWordCount?: number;
+  }
+
+  export interface BidirectionalAudio {
+    enabled?: boolean;
+    streaming?: boolean;
+    sampleRate?: number;
+  }
+
+  export interface CobaltOptions {
+    serverUri?: string;
+    enableConfusionNetwork?: boolean;
+    metadata?: string;
+    compiledContextData?: string;
+    wordTimeOffsets?: boolean;
+    contextToken?: string;
+  }
+
+  export interface CustomOptions {
+    authToken?: string;
+    uri?: string;
+    sampleRate?: number;
+    options?: Record<string, unknown>;
+  }
+
+  export interface DeepgramOptions {
+    deepgramSttUri?: string;
+    deepgramSttUseTls?: boolean;
+    apiKey?: string;
+    tier?: string;
+    model?: string;
+    customModel?: string;
+    version?: string;
+    punctuate?: boolean;
+    smartFormatting?: boolean;
+    noDelay?: boolean;
+    profanityFilter?: boolean;
+    redact?: 'pci' | 'numbers' | 'true' | 'ssn';
+    diarize?: boolean;
+    diarizeVersion?: string;
+    ner?: boolean;
+    multichannel?: boolean;
+    alternatives?: number;
+    numerals?: boolean;
+    search?: unknown[];
+    replace?: unknown[];
+    keywords?: unknown[];
+    keyterms?: unknown[];
+    endpointing?: boolean | number;
+    utteranceEndMs?: number;
+    shortUtterance?: boolean;
+    vadTurnoff?: number;
+    tag?: string;
+    fillerWords?: boolean;
+    eotThreshold?: number;
+    eotTimeoutMs?: number;
+    mipOptOut?: boolean;
+    entityPrompt?: string;
+    eagerEotThreshold?: number;
+  }
+
+  export interface DialFrom {
+    user?: string;
+    host?: string;
+  }
+
+  export interface ElevenlabsOptions {
+    includeTimestamps?: boolean;
+    commitStrategy?: 'manual' | 'vad';
+    vadSilenceThresholdSecs?: number;
+    vadThreshold?: number;
+    minSpeechDurationMs?: number;
+    minSilenceDurationMs?: number;
+    enableLogging?: boolean;
+  }
+
+  export interface FillerNoise {
+    enable: boolean;
+    url?: string;
+    startDelaySecs?: number;
+  }
+
+  export interface Formatting {
+    scheme: string;
+    options: Record<string, unknown>;
+  }
+
+  export interface GoogleOptions {
+    serviceVersion?: 'v1' | 'v2';
+    recognizerId?: string;
+    speechStartTimeoutMs?: number;
+    speechEndTimeoutMs?: number;
+    enableVoiceActivityEvents?: boolean;
+    transcriptNormalization?: unknown[];
+  }
+
+  export interface HoundifyOptions {
+    latitude?: number;
+    longitude?: number;
+    city?: string;
+    state?: string;
+    country?: string;
+    timeZone?: string;
+    domain?: string;
+    audioEndpoint?: string;
+    maxSilenceSeconds?: number;
+    maxSilenceAfterFullQuerySeconds?: number;
+    maxSilenceAfterPartialQuerySeconds?: number;
+    vadSensitivity?: number;
+    vadTimeout?: number;
+    vadMode?: string;
+    vadVoiceMs?: number;
+    vadSilenceMs?: number;
+    vadDebug?: boolean;
+    audioFormat?: string;
+    enableNoiseReduction?: boolean;
+    enableProfanityFilter?: boolean;
+    enablePunctuation?: boolean;
+    enableCapitalization?: boolean;
+    confidenceThreshold?: number;
+    enableDisfluencyFilter?: boolean;
+    maxResults?: number;
+    enableWordTimestamps?: boolean;
+    maxAlternatives?: number;
+    partialTranscriptInterval?: number;
+    sessionTimeout?: number;
+    connectionTimeout?: number;
+    customVocabulary?: unknown[];
+    languageModel?: string;
+  }
+
+  export interface IbmOptions {
+    sttApiKey?: string;
+    sttRegion?: string;
+    ttsApiKey?: string;
+    ttsRegion?: string;
+    instanceId?: string;
+    model?: string;
+    languageCustomizationId?: string;
+    acousticCustomizationId?: string;
+    baseModelVersion?: string;
+    watsonMetadata?: string;
+    watsonLearningOptOut?: boolean;
+  }
+
+  export interface LexIntent {
+    name: string;
+    slots?: Record<string, unknown>;
+  }
+
+  export interface ListenOptions {
+    enable: boolean;
+    url?: string;
+    sampleRate?: number;
+    wsAuth?: Auth;
+    mixType?: 'mono' | 'stereo' | 'mixed';
+    metadata?: Record<string, unknown>;
+    maxLength?: number;
+    passDtmf?: boolean;
+    playBeep?: boolean;
+    disableBidirectionalAudio?: boolean;
+    bidirectionalAudio?: BidirectionalAudio;
+    timeout?: number;
+  }
+
+  export interface McpServer {
+    url: string;
+    auth?: Record<string, unknown>;
+    roots?: Root[];
+  }
+
+  export interface NuanceOptions {
+    clientId?: string;
+    secret?: string;
+    kryptonEndpoint?: string;
+    topic?: string;
+    utteranceDetectionMode?: 'single' | 'multiple' | 'disabled';
+    punctuation?: boolean;
+    profanityFilter?: boolean;
+    includeTokenization?: boolean;
+    discardSpeakerAdaptation?: boolean;
+    suppressCallRecording?: boolean;
+    maskLoadFailures?: boolean;
+    suppressInitialCapitalization?: boolean;
+    allowZeroBaseLmWeight?: boolean;
+    filterWakeupWord?: boolean;
+    resultType?: 'final' | 'partial' | 'immutable_partial';
+    noInputTimeoutMs?: number;
+    recognitionTimeoutMs?: number;
+    utteranceEndSilenceMs?: number;
+    maxHypotheses?: number;
+    speechDomain?: string;
+    formatting?: Formatting;
+    clientData?: Record<string, unknown>;
+    userId?: string;
+    speechDetectionSensitivity?: number;
+    resources?: Resource[];
+  }
+
+  export interface NvidiaOptions {
+    rivaUri?: string;
+    maxAlternatives?: number;
+    profanityFilter?: boolean;
+    punctuation?: boolean;
+    wordTimeOffsets?: boolean;
+    verbatimTranscripts?: boolean;
+    customConfiguration?: Record<string, unknown>;
+  }
+
+  export interface OpenaiOptions {
+    apiKey?: string;
+    model?: string;
+    prompt?: string;
+    promptTemplates?: PromptTemplates;
+    language?: string;
+    input_audio_noise_reduction?: 'near_field' | 'far_field';
+    turn_detection?: TurnDetection;
+  }
+
+  export interface PromptTemplates {
+    hintsTemplate?: string;
+    conversationHistoryTemplate?: string;
+  }
+
+  export interface QueryInput {
+    text?: string;
+    intent?: string;
+    event?: string;
+    dtmf?: string;
+  }
+
+  export interface Recognizer {
+    vendor: string;
+    label?: string;
+    language?: string;
+    fallbackVendor?: string;
+    fallbackLabel?: string;
+    fallbackLanguage?: string;
+    vad?: Vad;
+    hints?: unknown[];
+    hintsBoost?: number;
+    altLanguages?: unknown[];
+    profanityFilter?: boolean;
+    interim?: boolean;
+    singleUtterance?: boolean;
+    dualChannel?: boolean;
+    separateRecognitionPerChannel?: boolean;
+    punctuation?: boolean;
+    enhancedModel?: boolean;
+    words?: boolean;
+    diarization?: boolean;
+    diarizationMinSpeakers?: number;
+    diarizationMaxSpeakers?: number;
+    interactionType?: 'unspecified' | 'discussion' | 'presentation' | 'phone_call' | 'voicemail' | 'voice_search' | 'voice_command' | 'dictation';
+    naicsCode?: number;
+    identifyChannels?: boolean;
+    vocabularyName?: string;
+    vocabularyFilterName?: string;
+    filterMethod?: 'remove' | 'mask' | 'tag';
+    model?: string;
+    outputFormat?: 'simple' | 'detailed';
+    profanityOption?: 'masked' | 'removed' | 'raw';
+    requestSnr?: boolean;
+    initialSpeechTimeoutMs?: number;
+    azureServiceEndpoint?: string;
+    azureSttEndpointId?: string;
+    asrDtmfTerminationDigit?: string;
+    asrTimeout?: number;
+    fastRecognitionTimeout?: number;
+    minConfidence?: number;
+    nuanceOptions?: NuanceOptions;
+    deepgramOptions?: DeepgramOptions;
+    ibmOptions?: IbmOptions;
+    nvidiaOptions?: NvidiaOptions;
+    sonioxOptions?: SonioxOptions;
+    cobaltOptions?: CobaltOptions;
+    awsOptions?: AwsOptions;
+    azureOptions?: AzureOptions;
+    assemblyAiOptions?: AssemblyAiOptions;
+    googleOptions?: GoogleOptions;
+    customOptions?: CustomOptions;
+    verbioOptions?: VerbioOptions;
+    speechmaticsOptions?: SpeechmaticsOptions;
+    openaiOptions?: OpenaiOptions;
+    houndifyOptions?: HoundifyOptions;
+    gladiaOptions?: Record<string, unknown>;
+    elevenlabsOptions?: ElevenlabsOptions;
+  }
+
+  export interface Record {
+    path: string;
+  }
+
+  export interface RecordOptions {
+    action: 'startCallRecording' | 'stopCallRecording' | 'pauseCallRecording' | 'resumeCallRecording';
+    recordingID?: string;
+    siprecServerURL?: string | unknown[];
+    headers?: Record<string, unknown>;
+  }
+
+  export interface Resource {
+    externalReference?: ResourceReference;
+    inlineWordset?: string;
+    builtin?: string;
+    inlineGrammar?: string;
+    wakeupWord?: unknown[];
+    weightName?: 'defaultWeight' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
+    weightValue?: number;
+    reuse?: 'undefined_reuse' | 'low_reuse' | 'high_reuse';
+  }
+
+  export interface ResourceReference {
+    type?: 'undefined_resource_type' | 'wordset' | 'compiled_wordset' | 'domain_lm' | 'speaker_profile' | 'grammar' | 'settings';
+    uri?: string;
+    maxLoadFailures?: boolean;
+    requestTimeoutMs?: number;
+    headers?: Record<string, unknown>;
+  }
+
+  export interface SmAudioEventsConfig {
+    types?: 'applause' | 'music' | 'laughter';
+  }
+
+  export interface SmAudioFilteringConfig {
+    volume_threshold: number;
+  }
+
+  export interface SmPuctuationOverrides {
+    permitted_marks?: unknown[];
+    sensitivity?: number;
+  }
+
+  export interface SmSpeakerDiarizationConfig {
+    speaker_sensitivity?: number;
+    max_speakers?: number;
+  }
+
+  export interface SmTranscriptFilteringConfig {
+    remove_disfluencies: boolean;
+  }
+
+  export interface SmTranscriptionConfig {
+    language?: string;
+    domain?: string;
+    additional_vocab?: unknown[];
+    diarization?: string;
+    speaker_diarization_config?: SmSpeakerDiarizationConfig;
+    enable_partials?: boolean;
+    max_delay?: number;
+    max_delay_mode?: 'fixed' | 'flexible';
+    output_locale?: string;
+    punctuation_overrides?: SmPuctuationOverrides;
+    operating_point?: string;
+    enable_entities?: boolean;
+    audio_filtering_config?: SmAudioFilteringConfig;
+    transcript_filtering_config?: SmTranscriptFilteringConfig;
+  }
+
+  export interface SmTranslationConfig {
+    target_languages: unknown[];
+    enable_partials?: boolean;
+  }
+
+  export interface SonioxOptions {
+    apiKey?: string;
+    model?: string;
+    endpointDetection?: boolean;
+    profanityFilter?: boolean;
+    speechContext?: string;
+    clientRequestReference?: string;
+    storage?: SonioxStorage;
+  }
+
+  export interface SonioxStorage {
+    id?: string;
+    title?: string;
+    disableStoreAudio?: boolean;
+    disableStoreTranscript?: boolean;
+    disableSearch?: boolean;
+    metadata?: Record<string, unknown>;
+  }
+
+  export interface SpeechmaticsOptions {
+    transcription_config?: SmTranscriptionConfig;
+    translation_config?: SmTranslationConfig;
+    audio_events_config_config?: SmAudioEventsConfig;
+  }
+
+  export interface Synthesizer {
+    vendor: string;
+    label?: string;
+    language?: string;
+    voice?: string | Record<string, unknown>;
+    fallbackVendor?: string;
+    fallbackLabel?: string;
+    fallbackLanguage?: string;
+    fallbackVoice?: string | Record<string, unknown>;
+    engine?: 'standard' | 'neural' | 'generative' | 'long-form';
+    gender?: 'MALE' | 'FEMALE' | 'NEUTRAL';
+    options?: Record<string, unknown>;
+  }
+
+  export interface Target {
+    type: 'phone' | 'sip' | 'user' | 'teams';
+    confirmHook?: Record<string, unknown> | string;
+    method?: 'GET' | 'POST';
+    headers?: Record<string, unknown>;
+    from?: DialFrom;
+    name?: string;
+    number?: string;
+    sipUri?: string;
+    auth?: Auth;
+    vmail?: boolean;
+    tenant?: string;
+    trunk?: string;
+    overrideTo?: string;
+    proxy?: string;
+  }
+
+  export interface TranscribeOptions {
+    enable: boolean;
+    transcriptionHook?: string;
+    recognizer?: Recognizer;
+  }
+
+  export interface TtsStream {
+    enable: boolean;
+    synthesizer?: Synthesizer;
+  }
+
+  export interface TurnDetection {
+    type: 'none' | 'server_vad' | 'semantic_vad';
+    eagerness?: 'low' | 'medium' | 'high' | 'auto';
+    threshold?: number;
+    prefix_padding_ms?: number;
+    silence_duration_ms?: number;
+  }
+
+  export interface TurnDetectionPipeline {
+    vendor: 'krisp';
+    threshold?: number;
+    eagerEotThreshold?: number;
+  }
+
+  export interface Vad {
+    enable?: boolean;
+    voiceMs?: number;
+    silenceMs?: number;
+    strategy?: string;
+    mode?: number;
+    vendor?: 'webrtc' | 'silero';
+    threshold?: number;
+    speechPadMs?: number;
+  }
+
+  export interface VerbioOptions {
+    enable_formatting?: boolean;
+    enable_diarization?: boolean;
+    topic?: number;
+    inline_grammar?: string;
+    grammar_uri?: string;
+    label?: string;
+    recognition_timeout?: number;
+    speech_complete_timeout?: number;
+    speech_incomplete_timeout?: number;
+  }
+
+  export interface Alert {
+    id?: string;
+    message: string;
+  }
+
+  export interface Answer {
+    id?: string;
+  }
+
+  export interface Conference {
+    id?: string;
+    name: string;
+    beep?: boolean;
+    memberTag?: string;
+    speakOnlyTo?: string;
+    startConferenceOnEnter?: boolean;
+    endConferenceOnExit?: boolean;
+    endConferenceDuration?: number;
+    maxParticipants?: number;
+    joinMuted?: boolean;
+    actionHook?: Record<string, unknown> | string;
+    waitHook?: Record<string, unknown> | string;
+    statusEvents?: unknown[];
+    statusHook?: Record<string, unknown> | string;
+    enterHook?: Record<string, unknown> | string;
+    record?: Record;
+    distributeDtmf?: boolean;
+  }
+
+  export interface Config {
+    id?: string;
+    synthesizer?: Synthesizer;
+    recognizer?: Recognizer;
+    bargeIn?: BargeIn;
+    ttsStream?: TtsStream;
+    record?: RecordOptions;
+    listen?: ListenOptions;
+    stream?: ListenOptions;
+    transcribe?: TranscribeOptions;
+    amd?: Amd;
+    fillerNoise?: FillerNoise;
+    notifyEvents?: boolean;
+    notifySttLatency?: boolean;
+    reset?: string | unknown[];
+    onHoldMusic?: string;
+    actionHookDelayAction?: ActionHookDelayAction;
+    sipRequestWithinDialogHook?: Record<string, unknown> | string;
+    boostAudioSignal?: number | string;
+    vad?: Vad;
+    referHook?: Record<string, unknown> | string;
+    earlyMedia?: boolean;
+    autoStreamTts?: boolean;
+    disableTtsCache?: boolean;
+  }
+
+  export interface Dequeue {
+    id?: string;
+    name: string;
+    actionHook?: Record<string, unknown> | string;
+    timeout?: number;
+    beep?: boolean;
+    callSid?: string;
+  }
+
+  export interface Dial {
+    id?: string;
+    actionHook?: Record<string, unknown> | string;
+    onHoldHook?: Record<string, unknown> | string;
+    answerOnBridge?: boolean;
+    callerId?: string;
+    callerName?: string;
+    confirmHook?: Record<string, unknown> | string;
+    referHook?: Record<string, unknown> | string;
+    dialMusic?: string;
+    dtmfCapture?: Record<string, unknown>;
+    dtmfHook?: Record<string, unknown> | string;
+    headers?: Record<string, unknown>;
+    anchorMedia?: boolean;
+    exitMediaPath?: boolean;
+    boostAudioSignal?: number | string;
+    listen?: Listen;
+    stream?: Listen;
+    target: Target[];
+    timeLimit?: number;
+    timeout?: number;
+    proxy?: string;
+    transcribe?: Transcribe;
+    amd?: Amd;
+    dub?: Dub[];
+    tag?: Record<string, unknown>;
+    forwardPAI?: boolean;
+  }
+
+  export interface Dialogflow {
+    id?: string;
+    credentials: Record<string, unknown> | string;
+    project: string;
+    agent?: string;
+    environment?: string;
+    region?: string;
+    model?: 'es' | 'cx';
+    lang: string;
+    actionHook?: Record<string, unknown> | string;
+    eventHook?: Record<string, unknown> | string;
+    events?: unknown[];
+    welcomeEvent?: string;
+    welcomeEventParams?: Record<string, unknown>;
+    noInputTimeout?: number;
+    noInputEvent?: string;
+    passDtmfAsTextInput?: boolean;
+    thinkingMusic?: string;
+    tts?: Synthesizer;
+    bargein?: boolean;
+    queryInput?: QueryInput;
+  }
+
+  export interface Dtmf {
+    id?: string;
+    dtmf: string;
+    duration?: number;
+  }
+
+  export interface Dub {
+    id?: string;
+    action: 'addTrack' | 'removeTrack' | 'silenceTrack' | 'playOnTrack' | 'sayOnTrack';
+    track: string;
+    play?: string;
+    say?: string | Record<string, unknown>;
+    loop?: boolean;
+    gain?: number | string;
+  }
+
+  export interface Enqueue {
+    id?: string;
+    name: string;
+    actionHook?: Record<string, unknown> | string;
+    waitHook?: Record<string, unknown> | string;
+    priority?: number;
+    _?: Record<string, unknown>;
+  }
+
+  export interface Gather {
+    id?: string;
+    actionHook?: Record<string, unknown> | string;
+    finishOnKey?: string;
+    input?: unknown[];
+    numDigits?: number;
+    minDigits?: number;
+    maxDigits?: number;
+    interDigitTimeout?: number;
+    partialResultHook?: Record<string, unknown> | string;
+    speechTimeout?: number;
+    listenDuringPrompt?: boolean;
+    dtmfBargein?: boolean;
+    bargein?: boolean;
+    minBargeinWordCount?: number;
+    timeout?: number;
+    recognizer?: Recognizer;
+    play?: Play;
+    say?: Say;
+    fillerNoise?: FillerNoise;
+    actionHookDelayAction?: ActionHookDelayAction;
+  }
+
+  export interface Hangup {
+    id?: string;
+    headers?: Record<string, unknown>;
+  }
+
+  export interface Leave {
+    id?: string;
+  }
+
+  export interface Lex {
+    id?: string;
+    botId: string;
+    botAlias: string;
+    credentials: Record<string, unknown>;
+    region: string;
+    locale?: string;
+    intent?: LexIntent;
+    welcomeMessage?: string;
+    metadata?: Record<string, unknown>;
+    bargein?: boolean;
+    passDtmf?: boolean;
+    actionHook?: Record<string, unknown> | string;
+    eventHook?: Record<string, unknown> | string;
+    noInputTimeout?: number;
+    tts?: Synthesizer;
+  }
+
+  export interface Listen {
+    id?: string;
+    actionHook?: Record<string, unknown> | string;
+    auth?: Auth;
+    finishOnKey?: string;
+    maxLength?: number;
+    metadata?: Record<string, unknown>;
+    mixType?: 'mono' | 'stereo' | 'mixed';
+    passDtmf?: boolean;
+    playBeep?: boolean;
+    disableBidirectionalAudio?: boolean;
+    bidirectionalAudio?: BidirectionalAudio;
+    sampleRate?: number;
+    timeout?: number;
+    transcribe?: Transcribe;
+    url: string;
+    wsAuth?: Auth;
+    earlyMedia?: boolean;
+    channel?: number;
+  }
+
+  export interface Llm {
+    id?: string;
+    vendor: string;
+    model?: string;
+    auth?: Record<string, unknown>;
+    connectOptions?: Record<string, unknown>;
+    mcpServers?: McpServer[];
+    actionHook?: Record<string, unknown> | string;
+    eventHook?: Record<string, unknown> | string;
+    toolHook?: Record<string, unknown> | string;
+    events?: unknown[];
+    llmOptions: Record<string, unknown>;
+  }
+
+  export interface Message {
+    id?: string;
+    carrier?: string;
+    account_sid?: string;
+    message_sid?: string;
+    to: string;
+    from: string;
+    text?: string;
+    media?: string | unknown[];
+    actionHook?: Record<string, unknown> | string;
+  }
+
+  export interface Pause {
+    id?: string;
+    length: number;
+  }
+
+  export interface Pipeline {
+    id?: string;
+    stt: Recognizer;
+    tts: Synthesizer;
+    vad?: Vad;
+    turnDetection?: TurnDetectionPipeline;
+    llm: Llm;
+    preflightLlm?: boolean;
+    actionHook?: Record<string, unknown> | string;
+    eventHook?: Record<string, unknown> | string;
+  }
+
+  export interface Play {
+    id?: string;
+    url: string | unknown[];
+    loop?: number | string;
+    earlyMedia?: boolean;
+    seekOffset?: number | string;
+    timeoutSecs?: number | string;
+    actionHook?: Record<string, unknown> | string;
+  }
+
+  export interface Rasa {
+    id?: string;
+    url: string;
+    recognizer?: Recognizer;
+    tts?: Synthesizer;
+    prompt?: string;
+    actionHook?: Record<string, unknown> | string;
+    eventHook?: Record<string, unknown> | string;
+  }
+
+  export interface Redirect {
+    id?: string;
+    actionHook: Record<string, unknown> | string;
+  }
+
+  export interface RestDial {
+    id?: string;
+    account_sid?: string;
+    application_sid?: string;
+    call_hook: Record<string, unknown> | string;
+    call_status_hook?: Record<string, unknown> | string;
+    from: string;
+    callerName?: string;
+    fromHost?: string;
+    speech_synthesis_vendor?: string;
+    speech_synthesis_voice?: string;
+    speech_synthesis_language?: string;
+    speech_recognizer_vendor?: string;
+    speech_recognizer_language?: string;
+    tag?: Record<string, unknown>;
+    to: Target;
+    headers?: Record<string, unknown>;
+    timeout?: number;
+    amd?: Amd;
+    dual_streams?: boolean;
+    sipRequestWithinDialogHook?: string;
+    referHook?: Record<string, unknown> | string;
+    timeLimit?: number;
+  }
+
+  export interface Say {
+    id?: string;
+    text?: string | unknown[];
+    instructions?: string;
+    stream?: boolean;
+    loop?: number | string;
+    synthesizer?: Synthesizer;
+    earlyMedia?: boolean;
+    disableTtsCache?: boolean;
+    closeStreamOnEmpty?: boolean;
+  }
+
+  export interface SipDecline {
+    id?: string;
+    status: number;
+    reason?: string;
+    headers?: Record<string, unknown>;
+  }
+
+  export interface SipRefer {
+    id?: string;
+    referTo: string;
+    referredBy?: string;
+    referredByDisplayName?: string;
+    headers?: Record<string, unknown>;
+    actionHook?: Record<string, unknown> | string;
+    eventHook?: Record<string, unknown> | string;
+  }
+
+  export interface SipRequest {
+    id?: string;
+    method: string;
+    body?: string;
+    headers?: Record<string, unknown>;
+    actionHook?: Record<string, unknown> | string;
+  }
+
+  export interface Stream {
+    id?: string;
+    actionHook?: Record<string, unknown> | string;
+    auth?: Auth;
+    finishOnKey?: string;
+    maxLength?: number;
+    metadata?: Record<string, unknown>;
+    mixType?: 'mono' | 'stereo' | 'mixed';
+    passDtmf?: boolean;
+    playBeep?: boolean;
+    disableBidirectionalAudio?: boolean;
+    bidirectionalAudio?: BidirectionalAudio;
+    sampleRate?: number;
+    timeout?: number;
+    transcribe?: Transcribe;
+    url: string;
+    wsAuth?: Auth;
+    earlyMedia?: boolean;
+  }
+
+  export interface Tag {
+    id?: string;
+    data: Record<string, unknown>;
+  }
+
+  export interface Transcribe {
+    id?: string;
+    transcriptionHook?: string;
+    translationHook?: string;
+    recognizer?: Recognizer;
+    earlyMedia?: boolean;
+    channel?: number;
+  }
+
+  // ============================================
+  // REST API Types (from calls.yaml + platform.yaml)
+  // ============================================
+
+  export interface JambonzOptions {
+    baseUrl: string;
+  }
+
+  export interface Webhook {
+    webhook_sid?: string;
+    url: string;
+    method?: 'get' | 'post';
+    username?: string;
+    password?: string;
+  }
+
+  export interface ApiTarget {
+    type: 'phone' | 'sip' | 'user' | 'teams';
+    number?: string;
+    sipUri?: string;
+    /** Microsoft Teams customer tenant domain name */
+    tenant?: string;
+    trunk?: string;
+    /** Dial directly into user's voicemail to leave a message */
+    vmail?: boolean;
+    overrideTo?: string;
+    name?: string;
+    auth?: {
+      username?: string;
+      password?: string;
+    };
+  }
+
+  export interface ApiCall {
+    account_sid: string;
+    application_sid?: string;
+    call_id: string;
+    call_sid: string;
+    call_status: 'trying' | 'ringing' | 'alerting' | 'in-progress' | 'completed' | 'busy' | 'no-answer' | 'failed' | 'queued';
+    caller_name?: string;
+    direction: 'inbound' | 'outbound';
+    duration?: number;
+    from: string;
+    originating_sip_trunk_name?: string;
+    parent_call_sid?: string;
+    service_url: string;
+    sip_status: number;
+    to: string;
+  }
+
+  export interface ApiApplication {
+    application_sid?: string;
+    name: string;
+    account_sid: string;
+    /** application webhook for inbound voice calls */
+    call_hook?: Webhook;
+    /** webhhok for reporting call status events */
+    call_status_hook?: Webhook;
+    /** application webhook for inbound SMS/MMS */
+    messaging_hook?: Webhook;
+    speech_synthesis_vendor?: string;
+    speech_synthesis_voice?: string;
+    speech_recognizer_vendor?: string;
+    speech_recognizer_language?: string;
+    /** Object containing the Application Environment Variables as key/value to be sent with the call_hook payload */
+    env_vars?: Record<string, unknown>;
+    record_all_calls?: boolean;
+  }
+
+  export interface Account {
+    account_sid: string;
+    name: string;
+    sip_realm?: string;
+    /** authentication webhook for registration */
+    registration_hook?: Webhook;
+    device_calling_application_sid?: string;
+    service_provider_sid: string;
+    record_all_calls?: boolean;
+    record_format?: 'wav' | 'mp3';
+    /** Credentials for recording storage */
+    bucket_credential?: {
+      vendor?: 'aws_s3' | 's3_compatible' | 'azure' | 'google';
+      region?: string;
+      /** name of the bucket */
+      name?: string;
+      access_key_id?: string;
+      secret_access_key?: string;
+    };
+  }
+
+  export interface VoipCarrier {
+    service_provider_sid: string;
+    name: string;
+    description?: string;
+    account_sid?: string;
+    application_sid?: string;
+    e164_leading_plus?: boolean;
+    requires_register?: boolean;
+    register_username?: string;
+    register_sip_realm?: string;
+    register_password?: string;
+    tech_prefix?: string;
+    diversion?: string;
+    is_active?: boolean;
+    smpp_system_id?: string;
+    smpp_password?: string;
+    smpp_inbound_system_id?: string;
+    smpp_inbound_password?: string;
+    smpp_enquire_link_interval?: number;
+    /** The type of trunk to create, see the [guide](/guides/using-the-jambonz-portal/basic-concepts/creating-carriers) for details */
+    trunk_type?: 'static_ip' | 'auth' | 'reg';
+    /** username for an auth trunk */
+    inbound_auth_username?: string;
+    /** password for an auth trunk */
+    inbound_auth_password?: string;
+  }
+
+  export interface SipGateway {
+    sip_gateway_sid: string;
+    ipv4: string;
+    port: number;
+    netmask: number;
+    voip_carrier_sid: string;
+    inbound?: boolean;
+    outbound?: boolean;
+  }
+
+  export interface SmppGateway {
+    smpp_gateway_sid: string;
+    ipv4: string;
+    port: number;
+    netmask: number;
+    voip_carrier_sid: string;
+    is_primary?: boolean;
+    use_tls?: boolean;
+    inbound?: boolean;
+    outbound?: boolean;
+  }
+
+  export interface PhoneNumber {
+    phone_number_sid: string;
+    number: string;
+    voip_carrier_sid: string;
+    account_sid?: string;
+    application_sid?: string;
+  }
+
+  export interface SpeechCredential {
+    speech_credential_sid?: string;
+    account_sid?: string;
+    vendor?: 'google' | 'aws';
+    service_key?: string;
+    access_key_id?: string;
+    secret_access_key?: string;
+    aws_region?: string;
+    last_used?: string;
+    last_tested?: string;
+    use_for_tts?: boolean;
+    use_for_stt?: boolean;
+    tts_tested_ok?: boolean;
+    stt_tested_ok?: boolean;
+    riva_server_uri?: string;
+  }
+
+  export interface ServiceProvider {
+    service_provider_sid: string;
+    name: string;
+    description?: string;
+    root_domain?: string;
+    /** authentication webhook for registration */
+    registration_hook?: Webhook;
+    ms_teams_fqdn?: string;
+    /** used for inbound testing for accounts on free plan */
+    test_number?: string;
+    /** name of test application that can be used for new signups */
+    test_application_name?: string;
+    /** identifies test application that can be used for new signups */
+    test_application_sid?: string;
+  }
+
+  export interface Registration {
+    registration_sid: string;
+    username: string;
+    domain: string;
+    sip_contact: string;
+    sip_user_agent?: string;
+  }
+
+  export interface ApiKey {
+    api_key_sid: string;
+    token: string;
+    account_sid?: string;
+    service_provider_sid?: string;
+    expires_at?: string;
+    created_at?: string;
+    last_used?: string;
+  }
+
+  export interface GeneralError {
+    msg: string;
+  }
+
+  export interface CreateCallOptions {
+    /** The application to use to control this call.  Either application_sid or call_hook is required. */
+    application_sid?: string;
+    /** If set to true, the inbound call will ring until the number that was dialed answers the call, and at that point a 200 OK will be sent on the inbound leg.  If false, the inbound call will be answered immediately as the outbound call is placed. */
+    answerOnBridge?: boolean;
+    call_hook?: Webhook;
+    call_status_hook?: Webhook;
+    /** The calling party number */
+    from: string;
+    /** The hostname to put in the SIP From header of the INVITE */
+    fromHost?: string;
+    /** The number of seconds to wait for call to be answered.  Defaults to 60. */
+    timeout?: number;
+    /** The max length of call in seconds */
+    timeLimit?: number;
+    /** Initial set of customer-supplied metadata to associate with the call (see jambonz 'tag' verb) */
+    tag?: Record<string, unknown>;
+    /** Destination for call */
+    to: ApiTarget;
+    /** The customer SIP headers to associate with the call */
+    headers?: Record<string, unknown>;
+    /** The sip indialog hook to receive session messages */
+    sipRequestWithinDialogHook?: string;
+    /** The vendor for Text to Speech (required if application_sid is not used) */
+    speech_synthesis_vendor?: string;
+    /** The language for Text to Speech (required if application_sid is not used) */
+    speech_synthesis_language?: string;
+    /** The voice for Text to Speech (required if application_sid is not used) */
+    speech_synthesis_voice?: string;
+    /** The vendor for Speech to Text (required if application_sid is not used) */
+    speech_recognizer_vendor?: string;
+    /** The language for Speech to Text (required if application_sid is not used) */
+    speech_recognizer_language?: string;
+    amd?: amd;
+  }
+
+  export interface UpdateCallOptions {
+    call_hook?: Webhook;
+    child_call_hook?: Webhook;
+    call_status?: 'completed' | 'no-answer';
+    conf_mute_status?: 'mute' | 'unmute';
+    conf_hold_status?: 'hold' | 'unhold';
+    listen_status?: 'pause' | 'silence' | 'resume';
+    mute_status?: 'mute' | 'unmute';
+    transcribe_status?: 'pause' | 'resume';
+    whisper?: {
+      /** See [Say](/verbs/verbs/say) or [Play](/verbs/verbs/play) for details of the properties */
+      verb?: 'say' | 'play';
+    } | {
+      /** See [Say](/verbs/verbs/say) or [Play](/verbs/verbs/play) for details of the properties */
+      verb?: 'say' | 'play';
+    }[];
+    sip_request?: {
+      method?: string;
+      content_type?: string;
+      content?: string;
+      headers?: Record<string, unknown>;
+    };
+    record?: {
+      action?: 'startCallRecording' | 'stopCallRecording' | 'pauseCallRecording' | 'resumeCallRecording';
+      recordingID?: string;
+      siprecServerURL?: string;
+    };
+    conferenceParticipantAction?: {
+      action?: 'tag' | 'untag' | 'coach' | 'uncoach' | 'mute' | 'unmute' | 'hold' | 'unhold';
+      tag?: string;
+    };
+    dtmf?: {
+      /** Single digit to send */
+      digit: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '0' | '*' | '#';
+      /** Duration of the tone in ms */
+      duration?: number;
+    };
+  }
+
+  export interface CreateApplicationOptions {
+    /** application name */
+    name: string;
+    account_sid: string;
+    /** application webhook to handle inbound voice calls */
+    call_hook: Webhook;
+    /** webhook to report call status events */
+    call_status_hook: Webhook;
+    /** application webhook to handle inbound SMS/MMS messages */
+    messaging_hook?: Webhook;
+    /** Voice Application Json, call_hook will not be invoked if app_json is provided */
+    app_json?: string;
+    speech_synthesis_vendor?: string;
+    speech_synthesis_voice?: string;
+    speech_recognizer_vendor?: string;
+    speech_recognizer_language?: string;
+    /** Object containing the Application Environment Variables as key/value to be sent with the call_hook payload */
+    env_vars?: Record<string, unknown>;
+  }
+
+  export interface UpdateApplicationOptions {
+    application_sid?: string;
+    name: string;
+    account_sid: string;
+    /** application webhook for inbound voice calls */
+    call_hook?: Webhook;
+    /** webhhok for reporting call status events */
+    call_status_hook?: Webhook;
+    /** application webhook for inbound SMS/MMS */
+    messaging_hook?: Webhook;
+    speech_synthesis_vendor?: string;
+    speech_synthesis_voice?: string;
+    speech_recognizer_vendor?: string;
+    speech_recognizer_language?: string;
+    /** Object containing the Application Environment Variables as key/value to be sent with the call_hook payload */
+    env_vars?: Record<string, unknown>;
+    record_all_calls?: boolean;
+  }
+
+  // ============================================
+  // Classes
+  // ============================================
+
+  export class Calls {
+    create(opts: CreateCallOptions): Promise<string>;
+    update(callSid: string, opts: UpdateCallOptions): Promise<void>;
+    list(opts?: Record<string, unknown>): Promise<ApiCall[]>;
+    retrieve(callSid: string): Promise<ApiCall>;
+    delete(callSid: string): Promise<void>;
+  }
+
+  export class Applications {
+    create(opts: CreateApplicationOptions): Promise<string>;
+    update(appSid: string, opts: UpdateApplicationOptions): Promise<void>;
+    list(opts?: Record<string, unknown>): Promise<ApiApplication[]>;
+    retrieve(appSid: string): Promise<ApiApplication>;
+    delete(appSid: string): Promise<void>;
+  }
+
+  export class Jambonz {
+    constructor(accountSid: string, apiKey: string, opts: JambonzOptions);
+    calls: Calls;
+    applications: Applications;
+  }
+
+  export class WebhookResponse {
+    payload: object[];
+    length: number;
+
+    constructor();
+
+    static verifyJambonzSignature(
+      secret: string | string[]
+    ): (req: unknown, res: unknown, next: () => void) => void;
+
+    toJSON(): object[];
+
+    // Verb methods
+    alert(payload: Alert): this;
+    answer(payload?: Answer): this;
+    sip_decline(payload: SipDecline): this;
+    sip_request(payload: SipRequest): this;
+    sip_refer(payload: SipRefer): this;
+    config(payload?: Config): this;
+    dub(payload: Dub): this;
+    dequeue(payload: Dequeue): this;
+    enqueue(payload: Enqueue): this;
+    leave(payload?: Leave): this;
+    hangup(payload?: Hangup): this;
+    play(payload: Play): this;
+    say(payload?: Say): this;
+    gather(payload?: Gather): this;
+    conference(payload: Conference): this;
+    dial(payload: Dial): this;
+    dialogflow(payload: Dialogflow): this;
+    dtmf(payload: Dtmf): this;
+    lex(payload: Lex): this;
+    listen(payload: Listen): this;
+    stream(payload: Stream): this;
+    llm(payload: Llm): this;
+    message(payload: Message): this;
+    pause(payload: Pause): this;
+    rasa(payload: Rasa): this;
+    redirect(payload: Redirect): this;
+    rest_dial(payload: RestDial): this;
+    tag(payload: Tag): this;
+    transcribe(payload?: Transcribe): this;
+    pipeline(payload: Pipeline): this;
+  }
+
+  // ============================================
+  // Exports
+  // ============================================
+
+  // Default export
+  function jambonz(accountSid: string, apiKey: string, opts: JambonzOptions): Jambonz;
+  export default jambonz;
+  export { jambonz };
+
+}


### PR DESCRIPTION
## Summary
Adds TypeScript type declarations for the SDK, generated from:
- `@jambonz/verb-specifications` (webhook verbs)
- OpenAPI spec (REST API types)

## Changes
- `types/jambonz-node-client.d.ts` — Generated type declarations
- `scripts/generate-types.js` — Script to regenerate types
- `schema/calls.yaml` + `schema/platform.yaml` — OpenAPI specs (retrieved from [Jambonz Fern Documentation repo](https://github.com/jambonz/jambonz-fern-config]))
- `package.json` — Added `types` field and `generate-types` script
- `.eslintignore` — Ignore types directory

## Usage
TypeScript users will now get full type support when importing the package.

Types can be regenerated with: `npm run generate-types`


## Updating Types
When the API is updated in the future, replace the YAML files in `/schema` with the updated versions and regenerate the types:

